### PR TITLE
Fix for optional database connection (DatabasePool?)

### DIFF
--- a/Sources/GRDBQuery/Query.swift
+++ b/Sources/GRDBQuery/Query.swift
@@ -58,7 +58,7 @@ extension Queryable {
 @propertyWrapper
 public struct Query<Request: Queryable>: DynamicProperty {
     /// Database access
-    @Environment private var database: Request.DatabaseContext
+    @Environment private var database: Request.DatabaseContext?
     
     /// The object that keeps on observing the database as long as it is alive.
     @StateObject private var tracker = Tracker()
@@ -84,7 +84,7 @@ public struct Query<Request: Queryable>: DynamicProperty {
     /// database in the environment.
     public init(
         _ request: Request,
-        in keyPath: KeyPath<EnvironmentValues, Request.DatabaseContext>)
+        in keyPath: KeyPath<EnvironmentValues, Request.DatabaseContext?>)
     {
         _database = Environment(keyPath)
         initialRequest = request
@@ -96,6 +96,11 @@ public struct Query<Request: Queryable>: DynamicProperty {
         if tracker.needsInitialRequest {
             tracker.request = initialRequest
         }
+        guard let database = database else {
+            print("GRDBQuery: ERROR, database not found in SwiftUI environment, no results will be returned")
+            return
+        }
+        
         tracker.startTrackingIfNecessary(in: database)
     }
     


### PR DESCRIPTION
Hi Gwendal, cheers again for your excellent GRDB library.

Here is a small patch that I found was necessary to use GRDBQuery with a DatabasePool. It simply makes the environment value optional, thus no default placeholder required (as we cannot make an in-memory pool).

It would also be reasonable to make the print statement at line 100 a `fatalError` in debug builds to make sure it gets noticed