### PR TITLE
Control @Query auto-updates

### DIFF
--- a/Sources/GRDBQuery/Documentation.docc/GettingStarted.md
+++ b/Sources/GRDBQuery/Documentation.docc/GettingStarted.md
@@ -90,7 +90,7 @@ The ``Queryable`` protocol has two requirements: a default value, and a Combine 
 
 > Note: In the above sample code, we make sure the views are *immediately* fed with database content with the `scheduling: .immediate` option. This prevents any blank state, "flash of missing content", or unwanted initial animation.
 >
-> The `scheduling: .immediate` option should be removed for database requests that are too slow, because the user interface would be blocked until the database values are fetched.
+> The `scheduling: .immediate` option should be removed for database accesses that are too slow, because the user interface would be blocked until the database values are fetched.
 >
 > If you remove `scheduling: .immediate`, views are initially fed with the default value, and the database content is notified later, when it becomes available. You can for example use a `nil` default value that your view can detect in order to display some waiting indicator, or a [redacted](https://developer.apple.com/documentation/swiftui/view/redacted(reason:)) placeholder.
 
@@ -148,6 +148,35 @@ struct PlayerList: View {
 >     ...
 > }
 > ```
+
+## Interrupting Automatic Updates 
+
+By default, `@Query` automatically updates the database values for the whole duration of the presence of the view in the SwiftUI engine.
+
+You can spare resources by stopping auto-updates when the view disappears, and restarting them when the view appears. To do so, use the `$players.isAutoupdating` SwiftUI binding, as in the example below:
+
+```swift
+import GRDBQuery
+import SwiftUI
+
+struct PlayerList: View {
+    @Query(PlayerRequest(), in: \.dbQueue)
+    var players: [Player]
+    
+    var body: some View {
+        List(players) { player in
+            HStack {
+                Text(player.name)
+                Spacer()
+                Text("\(player.score) points")
+            }
+        }
+        // Stop observing the database when the view disappears,
+        // and start again when the view appears.
+        .mirrorAppearanceState(to: $players.isAutoupdating)
+    }
+}
+```
 
 ## How to Handle Database Errors?
 

--- a/Sources/GRDBQuery/View.swift
+++ b/Sources/GRDBQuery/View.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+extension View {
+    /// Sets the providing bindings to true when this view appears, and to
+    /// false when this view disappears.
+    public func mirrorAppearanceState(to bindings: Binding<Bool>...) -> some View {
+        self
+            .onAppear {
+                for binding in bindings {
+                    binding.wrappedValue = true
+                }
+            }
+            .onDisappear {
+                for binding in bindings {
+                    binding.wrappedValue = false
+                }
+            }
+    }
+}


### PR DESCRIPTION
By default, `@Query` automatically updates the database values for the whole duration of the presence of the view in the SwiftUI engine.

You can now spare resources by stopping auto-updates when the view disappears, and restarting them when the view appears. To do so, use the `$players.isAutoupdating` SwiftUI binding, as in the example below:

```swift
import GRDBQuery
import SwiftUI

struct PlayerList: View {
    @Query(PlayerRequest(), in: \.dbQueue)
    var players: [Player]
    
    var body: some View {
        List(players) { player in
            HStack {
                Text(player.name)
                Spacer()
                Text("\(player.score) points")
            }
        }
        // Stop observing the database when the view disappears,
        // and start again when the view appears.
        .mirrorAppearanceState(to: $players.isAutoupdating)
    }
}
```

This great idea was suggested by @davedelong. Thank you!