### PR TITLE
Request Observation Control

### DIFF
--- a/Sources/GRDBQuery/Documentation.docc/Documentation.md
+++ b/Sources/GRDBQuery/Documentation.docc/Documentation.md
@@ -33,6 +33,7 @@ struct PlayerList: View {
 ### The @Query property wrapper
 
 - ``Query``
+- ``QueryObservation``
 
 ### Feeding @Query with database content
 

--- a/Sources/GRDBQuery/Documentation.docc/GettingStarted.md
+++ b/Sources/GRDBQuery/Documentation.docc/GettingStarted.md
@@ -163,34 +163,11 @@ struct PlayerList: View {
 > }
 > ```
 
-## Interrupting Automatic Updates 
+## Controlling Request Observation 
 
-By default, `@Query` automatically updates the database values for the whole duration of the presence of the view in the SwiftUI engine.
+By default, `@Query` observes its request for the whole duration of the presence of the view in the SwiftUI engine.
 
-You can spare resources by stopping auto-updates when the view disappears, and restarting them when the view appears. To do so, use the `$players.isAutoupdating` SwiftUI binding, as in the example below:
-
-```swift
-import GRDBQuery
-import SwiftUI
-
-struct PlayerList: View {
-    @Query(PlayerRequest(), in: \.dbQueue)
-    var players: [Player]
-    
-    var body: some View {
-        List(players) { player in
-            HStack {
-                Text(player.name)
-                Spacer()
-                Text("\(player.score) points")
-            }
-        }
-        // Stop observing the database when the view disappears,
-        // and start again when the view appears.
-        .mirrorAppearanceState(to: $players.isAutoupdating)
-    }
-}
-```
+You can spare resources by stopping request observation when views are not on screen: see ``QueryObservation``.
 
 ## How to Handle Database Errors?
 

--- a/Sources/GRDBQuery/QueryObservation.swift
+++ b/Sources/GRDBQuery/QueryObservation.swift
@@ -111,15 +111,13 @@ extension View {
     ///
     /// See ``QueryObservation`` for a complete discussion.
     @ViewBuilder public func queryObservation(_ queryObservation: QueryObservation) -> some View {
-        Group {
-            switch queryObservation {
-            case .always:
-                self.environment(\.queryObservationEnabled, true)
-            case .onRender:
-                QueryObservationWrapper(queryObservationEnabled: true, content: self)
-            case .onAppear:
-                QueryObservationWrapper(queryObservationEnabled: false, content: self)
-            }
+        switch queryObservation {
+        case .always:
+            self.environment(\.queryObservationEnabled, true)
+        case .onRender:
+            QueryObservationWrapper(queryObservationEnabled: true, content: self)
+        case .onAppear:
+            QueryObservationWrapper(queryObservationEnabled: false, content: self)
         }
     }
 }

--- a/Sources/GRDBQuery/View.swift
+++ b/Sources/GRDBQuery/View.swift
@@ -3,47 +3,93 @@ import SwiftUI
 /// A `QueryObservation` controls when `@Query` property wrappers are observing
 /// their requests.
 ///
-/// By default, `@Query` observes its request for the whole duration of the
-/// presence of the view in the SwiftUI engine.
+/// By default, `@Query` observes its ``Queryable`` request for the whole
+/// duration of the presence of the view in the SwiftUI engine: it subscribes
+/// to the request publisher before the first `body` rendering, and cancels the
+/// subscription when the view is no longer rendered.
 ///
 /// You can spare resources by stopping request observation when views are not
-/// on screen.
+/// on screen, with the `View.queryObservation(_:)` method. It enables request
+/// observation in the chosen time intervals, for all `@Query` property wrappers
+/// embedded in the view.
 ///
-/// If you imagine a timeline of view events:
+/// Given this general timeline of SwiftUI events:
 ///
-///        Initial body rendering
-///        |        onAppear         onAppear
-///        |        |    onDisappear |      onDisappear
-///        |        |    |           |      |
-///        •--------•----•-----------•------•--------> time
+///     Initial body rendering
+///     |    onAppear              onAppear
+///     |    |         onDisappear |         onDisappear
+///     |    |         |           |         |      End
+///     |    |         |           |         |      |
+///     •----•---------•-----------•---------•------•--> time
 ///
-/// The `View.queryObservation(_:)` method enables request observation in the
-/// chosen time intervals, for all `@Query` property wrappers embedded in
-/// the view:
+/// - Use `.always` (the default) for subscribing before the first `body`
+///   rendering, until the view leaves the SwiftUI engine:
 ///
-/// ```swift
-/// // •********•****•***********•******•********* .always
-/// MyView().queryObservation(.always)
+///     ```swift
+///     // Initial body rendering                      End
+///     // |                                           |
+///     // <···········································>
+///     // •----•---------•-----------•---------•------•--> time
+///     MyView().queryObservation(.always)
+///     ```
 ///
-/// // •********•****•-----------•******•--------- .onRender
-/// MyView().queryObservation(.onRender)
+/// - Use `.onRender` for subscribing before the first `body` rendering, and
+///   then using the `onDisappear` and `onAppear` SwiftUI events for pausing
+///   the subscription:
 ///
-/// // •--------•****•-----------•******•--------- .onAppear
-/// MyView().queryObservation(.onAppear)
-/// ```
+///     ```swift
+///     // Initial body rendering
+///     // |              onDisappear onAppear  onDisappear
+///     // |              |           |         |
+///     // <··············>           <·········>
+///     // •----•---------•-----------•---------•------•--> time
+///     MyView().queryObservation(.onRender)
+///     ```
 ///
-/// The default is `.always`.
+/// - Use `.onAppear` for letting the `onDisappear` and `onAppear` SwiftUI
+///   events control the subscription duration:
 ///
-/// Only `.onRender` and `.always` have `@Query` feed a view on its
-/// initial `body` rendering.
+///     ```swift
+///     //      onAppear  onDisappear onAppear  onDisappear
+///     //      |         |           |         |
+///     //      <·········>           <·········>
+///     // •----•---------•-----------•---------•------•--> time
+///     MyView().queryObservation(.onAppear)
+///     ```
 ///
-/// For more precise control of the request observation, do not use
-/// `View.queryObservation(_:)`, and deal manually with the
-/// `\.queryObservationEnabled` environment key instead:
+/// > Note: Only `.onRender` and `.always` have `@Query` feed a view on its
+/// > initial `body` rendering. This avoids SwiftUI animations for the initial
+/// > rendering of database values.
+///
+/// > Note: Unless the request publisher publishes its initial value right on
+/// > subscription, `.onRender` and `.onAppear` will have your view display
+/// > obsolete database values when they re-appear. See <doc:GettingStarted>
+/// > for more information about _immediate_ database publishers.
+///
+/// > Tip: For *fast and immediate* database publishers that publish their
+/// > initial value right on subscription, `QueryObservation.always` and
+/// > `.onRender` should fit most application needs.
+///
+/// > Tip: For *slow and asynchronous* database publishers that publish all
+/// > their values asynchronously, prefer `QueryObservation.always`, in order to
+/// > reduce the probability that the application user can see obsolete
+/// > database values.
+/// >
+/// > You can also consider using `.onAppear`, and prepending your request
+/// > publisher with a sentinel value that will allow your view to display a
+/// > loading indicator instead of obsolete database values, when the view
+/// > appears or re-appears.
+///
+/// When the built-in strategies do not fit the needs of your application, do
+/// not use `View.queryObservation(_:)`. Instead, deal directly with the
+/// `\.queryObservationEnabled` environment key:
 ///
 /// ```swift
 /// // Disables observation
 /// MyView().environment(\.queryObservationEnabled, false)
+///
+/// // Enables observation
+/// MyView().environment(\.queryObservationEnabled, true)
 /// ```
 public enum QueryObservation {
     /// Requests are always observed.
@@ -63,23 +109,7 @@ extension View {
     /// Controls when the `@Query` property wrappers observe their requests,
     /// in this view.
     ///
-    /// If you imagine a timeline of view events:
-    ///
-    ///     Initial body rendering
-    ///     |        onAppear         onAppear
-    ///     |        |    onDisappear |      onDisappear
-    ///     |        |    |           |      |
-    ///     •--------•----•-----------•------•--------> time
-    ///
-    /// Then `queryObservation(_:)` can enable observation in the chosen
-    /// time intervals:
-    ///
-    ///     •********•****•***********•******•********* .always
-    ///     •********•****•-----------•******•--------- .onRender
-    ///     •--------•****•-----------•******•--------- .onAppear
-    ///
-    /// The default is `.always`. Only `.onRender` and `.always` have `@Query`
-    /// feed your views on the initial `body` rendering.
+    /// See ``QueryObservation`` for a complete discussion.
     @ViewBuilder public func queryObservation(_ queryObservation: QueryObservation) -> some View {
         Group {
             switch queryObservation {

--- a/Sources/GRDBQuery/View.swift
+++ b/Sources/GRDBQuery/View.swift
@@ -1,22 +1,111 @@
 import SwiftUI
 
+/// A `QueryObservation` controls when `@Query` property wrappers are observing
+/// their requests.
+///
+/// By default, `@Query` observes its request for the whole duration of the
+/// presence of the view in the SwiftUI engine.
+///
+/// You can spare resources by stopping request observation when views are not
+/// on screen.
+///
+/// If you imagine a timeline of view events:
+///
+///        Initial rendering
+///        |        onAppear         onAppear
+///        |        |    onDisappear |      onDisappear
+///        |        |    |           |      |
+///        •--------•----•-----------•------•--------> time
+///
+/// The `View.queryObservation(_:)` method enables request observation in the
+/// chosen time intervals, for all `@Query` property wrappers embedded in
+/// the view:
+///
+/// ```swift
+/// // •********•****•***********•******•********* .always
+/// MyView().queryObservation(.always)
+///
+/// // •********•****•-----------•******•--------- .onRender
+/// MyView().queryObservation(.onRender)
+///
+/// // •--------•****•-----------•******•--------- .onAppear
+/// MyView().queryObservation(.onAppear)
+/// ```
+///
+/// The default is `.always`.
+///
+/// Only `.onRender` and `.always` have `@Query` feed a view on its
+/// initial rendering.
+///
+/// For more precise control of the request observation, do not use
+/// `View.queryObservation(_:)`, and deal manually with the
+/// `\.queryObservationEnabled` environment key instead:
+///
+/// ```swift
+/// // Disables observation
+/// MyView().environment(\.queryObservationEnabled, false)
+/// ```
+public enum QueryObservation {
+    /// Requests are always observed.
+    case always
+    
+    /// Request observation starts on the first rendering of the view, and is
+    /// later stopped and restarted according to the `onAppear` and
+    /// `onDisappear` View events.
+    case onRender
+    
+    /// Request observation starts and stops according to the `onAppear` and
+    /// `onDisappear` View events.
+    case onAppear
+}
+
 extension View {
-    /// Sets the providing bindings to true when this view appears, and to
-    /// false when this view disappears.
+    /// Controls when the `@Query` property wrappers observe their requests,
+    /// in this view.
     ///
-    /// This method is based on the `onAppear` and `onDisappear` built-in
-    /// `View` methods.
-    public func mirrorAppearanceState(to bindings: Binding<Bool>...) -> some View {
-        self
+    /// If you imagine a timeline of view events:
+    ///
+    ///     Initial rendering
+    ///     |        onAppear         onAppear
+    ///     |        |    onDisappear |      onDisappear
+    ///     |        |    |           |      |
+    ///     •--------•----•-----------•------•--------> time
+    ///
+    /// Then `queryObservation(_:)` can enable observation in the chosen
+    /// time intervals:
+    ///
+    ///     •********•****•***********•******•********* .always
+    ///     •********•****•-----------•******•--------- .onRender
+    ///     •--------•****•-----------•******•--------- .onAppear
+    ///
+    /// The default is `.always`. Only `.onRender` and `.always` have `@Query`
+    /// feed your views on the initial rendering.
+    @ViewBuilder public func queryObservation(_ queryObservation: QueryObservation) -> some View {
+        Group {
+            switch queryObservation {
+            case .always:
+                self.environment(\.queryObservationEnabled, true)
+            case .onRender:
+                QueryObservationWrapper(queryObservationEnabled: true, content: self)
+            case .onAppear:
+                QueryObservationWrapper(queryObservationEnabled: false, content: self)
+            }
+        }
+    }
+}
+
+private struct QueryObservationWrapper<Content: View>: View {
+    @State var queryObservationEnabled: Bool
+    var content: Content
+    
+    var body: some View {
+        content
+            .environment(\.queryObservationEnabled, queryObservationEnabled)
             .onAppear {
-                for binding in bindings {
-                    binding.wrappedValue = true
-                }
+                queryObservationEnabled = true
             }
             .onDisappear {
-                for binding in bindings {
-                    binding.wrappedValue = false
-                }
+                queryObservationEnabled = false
             }
     }
 }

--- a/Sources/GRDBQuery/View.swift
+++ b/Sources/GRDBQuery/View.swift
@@ -11,7 +11,7 @@ import SwiftUI
 ///
 /// If you imagine a timeline of view events:
 ///
-///        Initial rendering
+///        Initial body rendering
 ///        |        onAppear         onAppear
 ///        |        |    onDisappear |      onDisappear
 ///        |        |    |           |      |
@@ -35,7 +35,7 @@ import SwiftUI
 /// The default is `.always`.
 ///
 /// Only `.onRender` and `.always` have `@Query` feed a view on its
-/// initial rendering.
+/// initial `body` rendering.
 ///
 /// For more precise control of the request observation, do not use
 /// `View.queryObservation(_:)`, and deal manually with the
@@ -49,8 +49,8 @@ public enum QueryObservation {
     /// Requests are always observed.
     case always
     
-    /// Request observation starts on the first rendering of the view, and is
-    /// later stopped and restarted according to the `onAppear` and
+    /// Request observation starts on the first `body` rendering of the view,
+    /// and is later stopped and restarted according to the `onAppear` and
     /// `onDisappear` View events.
     case onRender
     
@@ -65,7 +65,7 @@ extension View {
     ///
     /// If you imagine a timeline of view events:
     ///
-    ///     Initial rendering
+    ///     Initial body rendering
     ///     |        onAppear         onAppear
     ///     |        |    onDisappear |      onDisappear
     ///     |        |    |           |      |
@@ -79,7 +79,7 @@ extension View {
     ///     •--------•****•-----------•******•--------- .onAppear
     ///
     /// The default is `.always`. Only `.onRender` and `.always` have `@Query`
-    /// feed your views on the initial rendering.
+    /// feed your views on the initial `body` rendering.
     @ViewBuilder public func queryObservation(_ queryObservation: QueryObservation) -> some View {
         Group {
             switch queryObservation {


### PR DESCRIPTION
This pull request addresses #19 by refactoring the api for controlling when requests are observed. The goal is still to spare resources when views are not on screen.

- The `isAutoupdating` binding has been removed, as well as `View.mirrorAppearanceState(to:)`.
- The "autoupdating" word is no longer used. Now "request observation" is "enabled" or not. This better matches SwiftUI wording: `@ObservedObject`, etc.
- Starting or stopping observation is no longer controlled by individual `@Query` instances. It is a matter of SwiftUI environment, so that request observation can be controlled in whole view hierarchies. For example, one can imagine a `TabView` with one tab containing multiple database-related views.
- One can use the convenience `View.queryObservation(_:)` method, or deal directly with the `\.queryObservationEnabled` environment key.

Find below an excerpt from the updated documentation:

---

By default, `@Query` observes its ``Queryable`` request for the whole duration of the presence of the view in the SwiftUI engine: it subscribes to the request publisher before the first `body` rendering, and cancels the subscription when the view is no longer rendered.

You can spare resources by stopping request observation when views are not on screen, with the `View.queryObservation(_:)` method. It enables request observation in the chosen time intervals, for all `@Query` property wrappers embedded in the view.

Given this general timeline of SwiftUI events:

    Initial body rendering
    |    onAppear              onAppear
    |    |         onDisappear |         onDisappear
    |    |         |           |         |      End
    |    |         |           |         |      |
    •----•---------•-----------•---------•------•--> time

- Use `.always` (the default) for subscribing before the first `body` rendering, until the view leaves the SwiftUI engine:

    ```swift
    // Initial body rendering                      End
    // |                                           |
    // <···········································>
    // •----•---------•-----------•---------•------•--> time
    MyView().queryObservation(.always)
    ```

- Use `.onRender` for subscribing before the first `body` rendering, and then using the `onDisappear` and `onAppear` SwiftUI events for pausing the subscription:

    ```swift
    // Initial body rendering
    // |              onDisappear onAppear  onDisappear
    // |              |           |         |
    // <··············>           <·········>
    // •----•---------•-----------•---------•------•--> time
    MyView().queryObservation(.onRender)
    ```

- Use `.onAppear` for letting the `onDisappear` and `onAppear` SwiftUI events control the subscription duration:

    ```swift
    //      onAppear  onDisappear onAppear  onDisappear
    //      |         |           |         |
    //      <·········>           <·········>
    // •----•---------•-----------•---------•------•--> time
    MyView().queryObservation(.onAppear)
    ```

> Note: Only `.onRender` and `.always` have `@Query` feed a view on its initial `body` rendering. This avoids SwiftUI animations for the initial rendering of database values.

> Note: Unless the request publisher publishes its initial value right on subscription, `.onRender` and `.onAppear` will have your view display obsolete database values when they re-appear. See <doc:GettingStarted> for more information about _immediate_ database publishers.

> Tip: For *fast and immediate* database publishers that publish their initial value right on subscription, `QueryObservation.always` and `.onRender` should fit most application needs.

> Tip: For *slow and asynchronous* database publishers that publish all their values asynchronously, prefer `QueryObservation.always`, in order to reduce the probability that the application user can see obsolete database values.
>
> You can also consider using `.onAppear`, and prepending your request publisher with a sentinel value that will allow your view to display a loading indicator instead of obsolete database values, when the view appears or re-appears.

When the built-in strategies do not fit the needs of your application, do not use `View.queryObservation(_:)`. Instead, deal directly with the `\.queryObservationEnabled` environment key:

```swift
// Disables observation
MyView().environment(\.queryObservationEnabled, false)

// Enables observation
MyView().environment(\.queryObservationEnabled, true)
```
