### PR TITLE
Tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,5 @@ let package = Package(
         .target(
             name: "GRDBQuery",
             dependencies: []),
-        .testTarget(
-            name: "GRDBQueryTests",
-            dependencies: ["GRDBQuery"]),
     ]
 )

--- a/Tests/GRDBQueryTests/QueryTests.swift
+++ b/Tests/GRDBQueryTests/QueryTests.swift
@@ -1,5 +1,0 @@
-import XCTest
-@testable import GRDBQuery
-
-final class QueryTests: XCTestCase {
-}

--- a/Tests/QueryTests/QueryTests.xcodeproj/project.pbxproj
+++ b/Tests/QueryTests/QueryTests.xcodeproj/project.pbxproj
@@ -1,0 +1,484 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		56D63F2A2833A72800B0BD2D /* QueryTestsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D63F292833A72800B0BD2D /* QueryTestsApp.swift */; };
+		56D63F2C2833A72800B0BD2D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D63F2B2833A72800B0BD2D /* ContentView.swift */; };
+		56D63F2E2833A72900B0BD2D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 56D63F2D2833A72900B0BD2D /* Assets.xcassets */; };
+		56D63F312833A72900B0BD2D /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 56D63F302833A72900B0BD2D /* Preview Assets.xcassets */; };
+		56D63F462833A72900B0BD2D /* QueryTestsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D63F452833A72900B0BD2D /* QueryTestsUITests.swift */; };
+		56D63F572833A98800B0BD2D /* GRDBQuery in Frameworks */ = {isa = PBXBuildFile; productRef = 56D63F562833A98800B0BD2D /* GRDBQuery */; };
+		56D63F592833AA3200B0BD2D /* ValueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D63F582833AA3200B0BD2D /* ValueView.swift */; };
+		56D63F5B2833B43E00B0BD2D /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D63F5A2833B43E00B0BD2D /* Request.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		56D63F422833A72900B0BD2D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 56D63F1E2833A72800B0BD2D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 56D63F252833A72800B0BD2D;
+			remoteInfo = QueryTests;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		56D63F262833A72800B0BD2D /* QueryTests.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = QueryTests.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		56D63F292833A72800B0BD2D /* QueryTestsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryTestsApp.swift; sourceTree = "<group>"; };
+		56D63F2B2833A72800B0BD2D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		56D63F2D2833A72900B0BD2D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		56D63F302833A72900B0BD2D /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		56D63F322833A72900B0BD2D /* QueryTests.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = QueryTests.entitlements; sourceTree = "<group>"; };
+		56D63F412833A72900B0BD2D /* QueryTestsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = QueryTestsUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		56D63F452833A72900B0BD2D /* QueryTestsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryTestsUITests.swift; sourceTree = "<group>"; };
+		56D63F542833A96600B0BD2D /* GRDBQuery */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = GRDBQuery; path = ../..; sourceTree = "<group>"; };
+		56D63F582833AA3200B0BD2D /* ValueView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValueView.swift; sourceTree = "<group>"; };
+		56D63F5A2833B43E00B0BD2D /* Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		56D63F232833A72800B0BD2D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				56D63F572833A98800B0BD2D /* GRDBQuery in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		56D63F3E2833A72900B0BD2D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		56D63F1D2833A72800B0BD2D = {
+			isa = PBXGroup;
+			children = (
+				56D63F542833A96600B0BD2D /* GRDBQuery */,
+				56D63F282833A72800B0BD2D /* QueryTests */,
+				56D63F442833A72900B0BD2D /* QueryTestsUITests */,
+				56D63F272833A72800B0BD2D /* Products */,
+				56D63F552833A98800B0BD2D /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		56D63F272833A72800B0BD2D /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				56D63F262833A72800B0BD2D /* QueryTests.app */,
+				56D63F412833A72900B0BD2D /* QueryTestsUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		56D63F282833A72800B0BD2D /* QueryTests */ = {
+			isa = PBXGroup;
+			children = (
+				56D63F292833A72800B0BD2D /* QueryTestsApp.swift */,
+				56D63F2B2833A72800B0BD2D /* ContentView.swift */,
+				56D63F5A2833B43E00B0BD2D /* Request.swift */,
+				56D63F582833AA3200B0BD2D /* ValueView.swift */,
+				56D63F2D2833A72900B0BD2D /* Assets.xcassets */,
+				56D63F322833A72900B0BD2D /* QueryTests.entitlements */,
+				56D63F2F2833A72900B0BD2D /* Preview Content */,
+			);
+			path = QueryTests;
+			sourceTree = "<group>";
+		};
+		56D63F2F2833A72900B0BD2D /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				56D63F302833A72900B0BD2D /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		56D63F442833A72900B0BD2D /* QueryTestsUITests */ = {
+			isa = PBXGroup;
+			children = (
+				56D63F452833A72900B0BD2D /* QueryTestsUITests.swift */,
+			);
+			path = QueryTestsUITests;
+			sourceTree = "<group>";
+		};
+		56D63F552833A98800B0BD2D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		56D63F252833A72800B0BD2D /* QueryTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 56D63F4B2833A72900B0BD2D /* Build configuration list for PBXNativeTarget "QueryTests" */;
+			buildPhases = (
+				56D63F222833A72800B0BD2D /* Sources */,
+				56D63F232833A72800B0BD2D /* Frameworks */,
+				56D63F242833A72800B0BD2D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = QueryTests;
+			packageProductDependencies = (
+				56D63F562833A98800B0BD2D /* GRDBQuery */,
+			);
+			productName = QueryTests;
+			productReference = 56D63F262833A72800B0BD2D /* QueryTests.app */;
+			productType = "com.apple.product-type.application";
+		};
+		56D63F402833A72900B0BD2D /* QueryTestsUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 56D63F512833A72900B0BD2D /* Build configuration list for PBXNativeTarget "QueryTestsUITests" */;
+			buildPhases = (
+				56D63F3D2833A72900B0BD2D /* Sources */,
+				56D63F3E2833A72900B0BD2D /* Frameworks */,
+				56D63F3F2833A72900B0BD2D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				56D63F432833A72900B0BD2D /* PBXTargetDependency */,
+			);
+			name = QueryTestsUITests;
+			productName = QueryTestsUITests;
+			productReference = 56D63F412833A72900B0BD2D /* QueryTestsUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		56D63F1E2833A72800B0BD2D /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1330;
+				LastUpgradeCheck = 1330;
+				TargetAttributes = {
+					56D63F252833A72800B0BD2D = {
+						CreatedOnToolsVersion = 13.3.1;
+					};
+					56D63F402833A72900B0BD2D = {
+						CreatedOnToolsVersion = 13.3.1;
+						TestTargetID = 56D63F252833A72800B0BD2D;
+					};
+				};
+			};
+			buildConfigurationList = 56D63F212833A72800B0BD2D /* Build configuration list for PBXProject "QueryTests" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 56D63F1D2833A72800B0BD2D;
+			productRefGroup = 56D63F272833A72800B0BD2D /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				56D63F252833A72800B0BD2D /* QueryTests */,
+				56D63F402833A72900B0BD2D /* QueryTestsUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		56D63F242833A72800B0BD2D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				56D63F312833A72900B0BD2D /* Preview Assets.xcassets in Resources */,
+				56D63F2E2833A72900B0BD2D /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		56D63F3F2833A72900B0BD2D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		56D63F222833A72800B0BD2D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				56D63F2C2833A72800B0BD2D /* ContentView.swift in Sources */,
+				56D63F5B2833B43E00B0BD2D /* Request.swift in Sources */,
+				56D63F592833AA3200B0BD2D /* ValueView.swift in Sources */,
+				56D63F2A2833A72800B0BD2D /* QueryTestsApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		56D63F3D2833A72900B0BD2D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				56D63F462833A72900B0BD2D /* QueryTestsUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		56D63F432833A72900B0BD2D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 56D63F252833A72800B0BD2D /* QueryTests */;
+			targetProxy = 56D63F422833A72900B0BD2D /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		56D63F492833A72900B0BD2D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		56D63F4A2833A72900B0BD2D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = Release;
+		};
+		56D63F4C2833A72900B0BD2D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = QueryTests/QueryTests.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"QueryTests/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.github.groue.QueryTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		56D63F4D2833A72900B0BD2D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = QueryTests/QueryTests.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"QueryTests/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.github.groue.QueryTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		56D63F522833A72900B0BD2D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.github.groue.QueryTestsUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = QueryTests;
+			};
+			name = Debug;
+		};
+		56D63F532833A72900B0BD2D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.github.groue.QueryTestsUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = QueryTests;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		56D63F212833A72800B0BD2D /* Build configuration list for PBXProject "QueryTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				56D63F492833A72900B0BD2D /* Debug */,
+				56D63F4A2833A72900B0BD2D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		56D63F4B2833A72900B0BD2D /* Build configuration list for PBXNativeTarget "QueryTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				56D63F4C2833A72900B0BD2D /* Debug */,
+				56D63F4D2833A72900B0BD2D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		56D63F512833A72900B0BD2D /* Build configuration list for PBXNativeTarget "QueryTestsUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				56D63F522833A72900B0BD2D /* Debug */,
+				56D63F532833A72900B0BD2D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		56D63F562833A98800B0BD2D /* GRDBQuery */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = GRDBQuery;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 56D63F1E2833A72800B0BD2D /* Project object */;
+}

--- a/Tests/QueryTests/QueryTests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Tests/QueryTests/QueryTests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Tests/QueryTests/QueryTests.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Tests/QueryTests/QueryTests.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Tests/QueryTests/QueryTests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/QueryTests/QueryTests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "SwiftDocCPlugin",
+        "repositoryURL": "https://github.com/apple/swift-docc-plugin",
+        "state": {
+          "branch": null,
+          "revision": "3303b164430d9a7055ba484c8ead67a52f7b74f6",
+          "version": "1.0.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Tests/QueryTests/QueryTests.xcodeproj/xcshareddata/xcschemes/QueryTests.xcscheme
+++ b/Tests/QueryTests/QueryTests.xcodeproj/xcshareddata/xcschemes/QueryTests.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1330"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "56D63F252833A72800B0BD2D"
+               BuildableName = "QueryTests.app"
+               BlueprintName = "QueryTests"
+               ReferencedContainer = "container:QueryTests.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "56D63F402833A72900B0BD2D"
+               BuildableName = "QueryTestsUITests.xctest"
+               BlueprintName = "QueryTestsUITests"
+               ReferencedContainer = "container:QueryTests.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "56D63F252833A72800B0BD2D"
+            BuildableName = "QueryTests.app"
+            BlueprintName = "QueryTests"
+            ReferencedContainer = "container:QueryTests.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "56D63F252833A72800B0BD2D"
+            BuildableName = "QueryTests.app"
+            BlueprintName = "QueryTests"
+            ReferencedContainer = "container:QueryTests.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tests/QueryTests/QueryTests/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Tests/QueryTests/QueryTests/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/QueryTests/QueryTests/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Tests/QueryTests/QueryTests/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/QueryTests/QueryTests/Assets.xcassets/Contents.json
+++ b/Tests/QueryTests/QueryTests/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/QueryTests/QueryTests/ContentView.swift
+++ b/Tests/QueryTests/QueryTests/ContentView.swift
@@ -15,15 +15,16 @@ struct ContentView: View {
     var body: some View {
         TabView {
             VStack {
-                Button("Change First") {
+                Button("Change Request") {
                     request.first = 5
                 }
+                .accessibilityIdentifier("container.changeRequestButton")
                 
                 Button("Send Test Notification") {
                     NotificationCenter.default.post(name: .test, object: nil)
                 }
                 .accessibilityIdentifier("shared.notificationButton")
-
+                
                 Button("Change ID") {
                     id += 1
                 }
@@ -33,7 +34,6 @@ struct ContentView: View {
                 }
                 
                 VStack {
-                    // Default request
                     ValueView(accessibilityIdentifier: "default")
                     ValueView(initialRequest: request, accessibilityIdentifier: "initial")
                     ValueView(constantRequest: request, accessibilityIdentifier: "constant")
@@ -51,7 +51,7 @@ struct ContentView: View {
             ValueView(accessibilityIdentifier: "queryObservation.onAppear")
                 .queryObservation(.onAppear)
                 .tabItem { Label("queryObservation.onAppear", image: "info") }
-
+            
             ValueView(accessibilityIdentifier: "queryObservation.onRender")
                 .queryObservation(.onRender)
                 .tabItem { Label("queryObservation.onRender", image: "info") }

--- a/Tests/QueryTests/QueryTests/ContentView.swift
+++ b/Tests/QueryTests/QueryTests/ContentView.swift
@@ -1,0 +1,50 @@
+//
+//  ContentView.swift
+//  QueryTests
+//
+//  Created by Gwendal Roué on 17/05/2022.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    @State var request = Request(first: 1, second: 1)
+    @State var id = 0
+    @State var queryObservationEnabled = true
+    
+    var body: some View {
+        VStack {
+            Button("Change First") {
+                request.first = 5
+            }
+            
+            Button("Send Test Notification") {
+                NotificationCenter.default.post(name: .test, object: nil)
+            }
+            
+            Button("Change ID") {
+                id += 1
+            }
+            
+            Button("Toggle Query Observation") {
+                queryObservationEnabled.toggle()
+            }
+            
+            VStack {
+                // Default request
+                ValueView(accessibilityIdentifier: "default")
+                ValueView(initialRequest: request, accessibilityIdentifier: "initial")
+                ValueView(constantRequest: request, accessibilityIdentifier: "constant")
+                ValueView($request, accessibilityIdentifier: "binding")
+            }
+            .id(id)
+        }
+        .environment(\.queryObservationEnabled, queryObservationEnabled)
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/Tests/QueryTests/QueryTests/ContentView.swift
+++ b/Tests/QueryTests/QueryTests/ContentView.swift
@@ -13,33 +13,49 @@ struct ContentView: View {
     @State var queryObservationEnabled = true
     
     var body: some View {
-        VStack {
-            Button("Change First") {
-                request.first = 5
-            }
-            
-            Button("Send Test Notification") {
-                NotificationCenter.default.post(name: .test, object: nil)
-            }
-            
-            Button("Change ID") {
-                id += 1
-            }
-            
-            Button("Toggle Query Observation") {
-                queryObservationEnabled.toggle()
-            }
-            
+        TabView {
             VStack {
-                // Default request
-                ValueView(accessibilityIdentifier: "default")
-                ValueView(initialRequest: request, accessibilityIdentifier: "initial")
-                ValueView(constantRequest: request, accessibilityIdentifier: "constant")
-                ValueView($request, accessibilityIdentifier: "binding")
+                Button("Change First") {
+                    request.first = 5
+                }
+                
+                Button("Send Test Notification") {
+                    NotificationCenter.default.post(name: .test, object: nil)
+                }
+                .accessibilityIdentifier("shared.notificationButton")
+
+                Button("Change ID") {
+                    id += 1
+                }
+                
+                Button("Toggle Query Observation") {
+                    queryObservationEnabled.toggle()
+                }
+                
+                VStack {
+                    // Default request
+                    ValueView(accessibilityIdentifier: "default")
+                    ValueView(initialRequest: request, accessibilityIdentifier: "initial")
+                    ValueView(constantRequest: request, accessibilityIdentifier: "constant")
+                    ValueView($request, accessibilityIdentifier: "binding")
+                }
+                .id(id)
             }
-            .id(id)
+            .tabItem { Label("Tab 1", image: "info") }
+            .environment(\.queryObservationEnabled, queryObservationEnabled)
+            
+            ValueView(accessibilityIdentifier: "queryObservation.always")
+                .queryObservation(.always)
+                .tabItem { Label("queryObservation.always", image: "info") }
+            
+            ValueView(accessibilityIdentifier: "queryObservation.onAppear")
+                .queryObservation(.onAppear)
+                .tabItem { Label("queryObservation.onAppear", image: "info") }
+
+            ValueView(accessibilityIdentifier: "queryObservation.onRender")
+                .queryObservation(.onRender)
+                .tabItem { Label("queryObservation.onRender", image: "info") }
         }
-        .environment(\.queryObservationEnabled, queryObservationEnabled)
     }
 }
 

--- a/Tests/QueryTests/QueryTests/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Tests/QueryTests/QueryTests/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/QueryTests/QueryTests/QueryTests.entitlements
+++ b/Tests/QueryTests/QueryTests/QueryTests.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-only</key>
+    <true/>
+</dict>
+</plist>

--- a/Tests/QueryTests/QueryTests/QueryTestsApp.swift
+++ b/Tests/QueryTests/QueryTests/QueryTestsApp.swift
@@ -1,0 +1,17 @@
+//
+//  QueryTestsApp.swift
+//  QueryTests
+//
+//  Created by Gwendal Roué on 17/05/2022.
+//
+
+import SwiftUI
+
+@main
+struct QueryTestsApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Tests/QueryTests/QueryTests/Request.swift
+++ b/Tests/QueryTests/QueryTests/Request.swift
@@ -1,0 +1,45 @@
+//
+//  Request.swift
+//  QueryTests
+//
+//  Created by Gwendal Roué on 17/05/2022.
+//
+
+import Combine
+import Foundation
+import GRDBQuery
+import SwiftUI
+
+private struct VoidKey: EnvironmentKey {
+    static var defaultValue: Void { () }
+}
+
+extension EnvironmentValues {
+    var void: Void {
+        get { self[VoidKey.self] }
+        set { self[VoidKey.self] = newValue }
+    }
+}
+
+extension Notification.Name {
+    static let test = Notification.Name("test")
+}
+
+struct Request: Queryable {
+    static var defaultValue: Int { 0 }
+    var first: Int
+    var second: Int
+    
+    /// Publishes `n + (first * second)`, where `n` is the number of received
+    /// "test" notifications.
+    ///
+    /// The first value `first * second` is published right on subscription.
+    func publisher(in _: Void) -> AnyPublisher<Int, Never> {
+        NotificationCenter.default
+            .publisher(for: .test)
+            .scan(0) { (n, _) in n + 1 }
+            .prepend(0)
+            .map { $0 + first * second }
+            .eraseToAnyPublisher()
+    }
+}

--- a/Tests/QueryTests/QueryTests/ValueView.swift
+++ b/Tests/QueryTests/QueryTests/ValueView.swift
@@ -40,6 +40,11 @@ struct ValueView: View {
                 $value.request.wrappedValue.second = 7
             }
             .accessibilityIdentifier("\(accessibilityIdentifier).button")
+            
+            Button("Send Test Notification") {
+                NotificationCenter.default.post(name: .test, object: nil)
+            }
+            .accessibilityIdentifier("\(accessibilityIdentifier).notificationButton")
         }
         .padding()
     }

--- a/Tests/QueryTests/QueryTests/ValueView.swift
+++ b/Tests/QueryTests/QueryTests/ValueView.swift
@@ -1,0 +1,52 @@
+//
+//  ValueView.swift
+//  QueryTests
+//
+//  Created by Gwendal Roué on 17/05/2022.
+//
+
+import GRDBQuery
+import SwiftUI
+
+struct ValueView: View {
+    var accessibilityIdentifier: String
+    @Query(Request(first: 2, second: 3), in: \.void) var value
+    
+    init(accessibilityIdentifier: String) {
+        self.accessibilityIdentifier = accessibilityIdentifier
+    }
+    
+    init(initialRequest request: Request, accessibilityIdentifier: String) {
+        self.accessibilityIdentifier = accessibilityIdentifier
+        _value = Query(request, in: \.void)
+    }
+    
+    init(constantRequest request: Request, accessibilityIdentifier: String) {
+        self.accessibilityIdentifier = accessibilityIdentifier
+        _value = Query(constant: request, in: \.void)
+    }
+    
+    init(_ request: Binding<Request>, accessibilityIdentifier: String) {
+        self.accessibilityIdentifier = accessibilityIdentifier
+        _value = Query(request, in: \.void)
+    }
+    
+    var body: some View {
+        HStack {
+            Text(verbatim: "\(value)")
+                .accessibilityIdentifier("\(accessibilityIdentifier).value")
+            
+            Button("Change Second") {
+                $value.request.wrappedValue.second = 7
+            }
+            .accessibilityIdentifier("\(accessibilityIdentifier).button")
+        }
+        .padding()
+    }
+}
+
+struct ValueView_Previews: PreviewProvider {
+    static var previews: some View {
+        ValueView(accessibilityIdentifier: "ignored")
+    }
+}

--- a/Tests/QueryTests/QueryTests/ValueView.swift
+++ b/Tests/QueryTests/QueryTests/ValueView.swift
@@ -12,20 +12,24 @@ struct ValueView: View {
     var accessibilityIdentifier: String
     @Query(Request(first: 2, second: 3), in: \.void) var value
     
+    /// Default request
     init(accessibilityIdentifier: String) {
         self.accessibilityIdentifier = accessibilityIdentifier
     }
     
+    /// Initial request
     init(initialRequest request: Request, accessibilityIdentifier: String) {
         self.accessibilityIdentifier = accessibilityIdentifier
         _value = Query(request, in: \.void)
     }
     
+    /// Constant request
     init(constantRequest request: Request, accessibilityIdentifier: String) {
         self.accessibilityIdentifier = accessibilityIdentifier
         _value = Query(constant: request, in: \.void)
     }
     
+    /// Request binding
     init(_ request: Binding<Request>, accessibilityIdentifier: String) {
         self.accessibilityIdentifier = accessibilityIdentifier
         _value = Query(request, in: \.void)
@@ -36,10 +40,10 @@ struct ValueView: View {
             Text(verbatim: "\(value)")
                 .accessibilityIdentifier("\(accessibilityIdentifier).value")
             
-            Button("Change Second") {
+            Button("Change Request") {
                 $value.request.wrappedValue.second = 7
             }
-            .accessibilityIdentifier("\(accessibilityIdentifier).button")
+            .accessibilityIdentifier("\(accessibilityIdentifier).changeRequestButton")
             
             Button("Send Test Notification") {
                 NotificationCenter.default.post(name: .test, object: nil)

--- a/Tests/QueryTests/QueryTestsUITests/QueryTestsUITests.swift
+++ b/Tests/QueryTests/QueryTestsUITests/QueryTestsUITests.swift
@@ -1,0 +1,184 @@
+//
+//  QueryTestsUITests.swift
+//  QueryTestsUITests
+//
+//  Created by Gwendal Roué on 17/05/2022.
+//
+
+import XCTest
+
+class QueryTestsUITests: XCTestCase {
+    
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+    
+    // Default request:
+    // - The value holding the `@Query` can alter the request.
+    // - The container view can NOT alter the request.
+    func testDefaultRequest() throws {
+        let app = XCUIApplication()
+        app.launch()
+        
+        let text = app.staticTexts["default.value"]
+        let changeSecondButton = app.buttons["default.button"]
+        
+        // `n + (first * second)` where n is zero
+        XCTAssertEqual(text.value as? String, "6")
+        
+        // `n + (first * second)` where `first` was changed
+        app.buttons["Change First"].tap()
+        XCTAssertEqual(text.value as? String, "6")
+        
+        // `n + (first * second)` where `second` was changed
+        changeSecondButton.tap()
+        XCTAssertEqual(text.value as? String, "14")
+        
+        // `n + (first * second)` where `n` was incremented
+        app.buttons["Send Test Notification"].tap()
+        XCTAssertEqual(text.value as? String, "15")
+        
+        // `n + (first * second)` where publisher was reset due to View ID change
+        app.buttons["Change ID"].tap()
+        XCTAssertEqual(text.value as? String, "6")
+        
+        // Stop publisher subscription
+        app.buttons["Toggle Query Observation"].tap()
+        app.buttons["Send Test Notification"].tap()
+        XCTAssertEqual(text.value as? String, "6")
+        
+        // Restart publisher subscription
+        app.buttons["Toggle Query Observation"].tap()
+        app.buttons["Send Test Notification"].tap()
+        XCTAssertEqual(text.value as? String, "7")
+    }
+    
+    // Initial request:
+    // - The value holding the `@Query` can alter the request.
+    // - The container view can NOT alter the request.
+    func testInitialRequest() throws {
+        let app = XCUIApplication()
+        app.launch()
+        
+        let text = app.staticTexts["initial.value"]
+        let changeSecondButton = app.buttons["initial.button"]
+        
+        // `n + (first * second)` where n is zero
+        XCTAssertEqual(text.value as? String, "1")
+        
+        // `n + (first * second)` where `first` was changed
+        app.buttons["Change First"].tap()
+        XCTAssertEqual(text.value as? String, "1")
+        
+        // `n + (first * second)` where `second` was changed
+        changeSecondButton.tap()
+        XCTAssertEqual(text.value as? String, "7")
+        
+        // `n + (first * second)` where `n` was incremented
+        app.buttons["Send Test Notification"].tap()
+        XCTAssertEqual(text.value as? String, "8")
+        
+        // `n + (first * second)` where publisher was reset due to View ID change
+        app.buttons["Change ID"].tap()
+        XCTAssertEqual(text.value as? String, "5")
+        
+        // Stop publisher subscription
+        app.buttons["Toggle Query Observation"].tap()
+        app.buttons["Send Test Notification"].tap()
+        XCTAssertEqual(text.value as? String, "5")
+        
+        // Restart publisher subscription
+        app.buttons["Toggle Query Observation"].tap()
+        app.buttons["Send Test Notification"].tap()
+        XCTAssertEqual(text.value as? String, "6")
+    }
+    
+    // Constant request:
+    // - The value holding the `@Query` can NOT alter the request.
+    // - The container view can alter the request.
+    func testConstantRequest() throws {
+        let app = XCUIApplication()
+        app.launch()
+        
+        let text = app.staticTexts["constant.value"]
+        let changeSecondButton = app.buttons["constant.button"]
+        
+        // `n + (first * second)` where n is zero
+        XCTAssertEqual(text.value as? String, "1")
+        
+        // `n + (first * second)` where `first` was changed
+        app.buttons["Change First"].tap()
+        XCTAssertEqual(text.value as? String, "5")
+        
+        // `n + (first * second)` where `second` was changed
+        changeSecondButton.tap()
+        XCTAssertEqual(text.value as? String, "5")
+        
+        // `n + (first * second)` where `n` was incremented
+        app.buttons["Send Test Notification"].tap()
+        XCTAssertEqual(text.value as? String, "6")
+        
+        // `n + (first * second)` where publisher was reset due to View ID change
+        app.buttons["Change ID"].tap()
+        XCTAssertEqual(text.value as? String, "5")
+        
+        // Stop publisher subscription
+        app.buttons["Toggle Query Observation"].tap()
+        app.buttons["Send Test Notification"].tap()
+        XCTAssertEqual(text.value as? String, "5")
+        
+        // Restart publisher subscription
+        app.buttons["Toggle Query Observation"].tap()
+        app.buttons["Send Test Notification"].tap()
+        XCTAssertEqual(text.value as? String, "6")
+    }
+    
+    // Request binding:
+    // - The value holding the `@Query` can alter the request.
+    // - The container view can alter the request.
+    func testBindingRequest() throws {
+        let app = XCUIApplication()
+        app.launch()
+        
+        let text = app.staticTexts["binding.value"]
+        let changeSecondButton = app.buttons["binding.button"]
+        
+        // `n + (first * second)` where n is zero
+        XCTAssertEqual(text.value as? String, "1")
+        
+        // `n + (first * second)` where `first` was changed
+        app.buttons["Change First"].tap()
+        XCTAssertEqual(text.value as? String, "5")
+        
+        // `n + (first * second)` where `second` was changed
+        changeSecondButton.tap()
+        XCTAssertEqual(text.value as? String, "35")
+        
+        // `n + (first * second)` where `n` was incremented
+        app.buttons["Send Test Notification"].tap()
+        XCTAssertEqual(text.value as? String, "36")
+        
+        // `n + (first * second)` where publisher was reset due to View ID change
+        app.buttons["Change ID"].tap()
+        XCTAssertEqual(text.value as? String, "35")
+        
+        // Stop publisher subscription
+        app.buttons["Toggle Query Observation"].tap()
+        app.buttons["Send Test Notification"].tap()
+        XCTAssertEqual(text.value as? String, "35")
+        
+        // Restart publisher subscription
+        app.buttons["Toggle Query Observation"].tap()
+        app.buttons["Send Test Notification"].tap()
+        XCTAssertEqual(text.value as? String, "36")
+    }
+}
+
+extension Array {
+    mutating func popFirst() -> Element? {
+        if isEmpty {
+            return nil
+        }
+        return removeFirst()
+    }
+}

--- a/Tests/QueryTests/QueryTestsUITests/QueryTestsUITests.swift
+++ b/Tests/QueryTests/QueryTestsUITests/QueryTestsUITests.swift
@@ -28,18 +28,19 @@ class QueryTestsUITests: XCTestCase {
         app.tabs["Tab 1"].tap()
         
         let text = app.staticTexts["default.value"]
-        let changeSecondButton = app.buttons["default.button"]
+        let changeRequestButton = app.buttons["default.changeRequestButton"]
+        let containerChangeRequestButton = app.buttons["container.changeRequestButton"]
         let sharedNotificationButton = app.buttons["shared.notificationButton"]
         
         // `n + (first * second)` where n is zero
         XCTAssertEqual(text.value as? String, "6")
         
         // `n + (first * second)` where `first` was set to 5 from container view
-        app.buttons["Change First"].tap()
+        containerChangeRequestButton.tap()
         XCTAssertEqual(text.value as? String, "6")
         
         // `n + (first * second)` where `second` was set to 7 from ValueView
-        changeSecondButton.tap()
+        changeRequestButton.tap()
         XCTAssertEqual(text.value as? String, "14")
         
         // `n + (first * second)` where `n` was incremented
@@ -76,18 +77,19 @@ class QueryTestsUITests: XCTestCase {
         app.tabs["Tab 1"].tap()
         
         let text = app.staticTexts["initial.value"]
-        let changeSecondButton = app.buttons["initial.button"]
+        let changeRequestButton = app.buttons["initial.changeRequestButton"]
+        let containerChangeRequestButton = app.buttons["container.changeRequestButton"]
         let sharedNotificationButton = app.buttons["shared.notificationButton"]
         
         // `n + (first * second)` where n is zero
         XCTAssertEqual(text.value as? String, "1")
         
         // `n + (first * second)` where `first` was set to 5 from container view
-        app.buttons["Change First"].tap()
+        containerChangeRequestButton.tap()
         XCTAssertEqual(text.value as? String, "1")
         
         // `n + (first * second)` where `second` was set to 7 from ValueView
-        changeSecondButton.tap()
+        changeRequestButton.tap()
         XCTAssertEqual(text.value as? String, "7")
         
         // `n + (first * second)` where `n` was incremented
@@ -124,18 +126,19 @@ class QueryTestsUITests: XCTestCase {
         app.tabs["Tab 1"].tap()
         
         let text = app.staticTexts["constant.value"]
-        let changeSecondButton = app.buttons["constant.button"]
+        let changeRequestButton = app.buttons["constant.changeRequestButton"]
+        let containerChangeRequestButton = app.buttons["container.changeRequestButton"]
         let sharedNotificationButton = app.buttons["shared.notificationButton"]
         
         // `n + (first * second)` where n is zero
         XCTAssertEqual(text.value as? String, "1")
         
         // `n + (first * second)` where `first` was set to 5 from container view
-        app.buttons["Change First"].tap()
+        containerChangeRequestButton.tap()
         XCTAssertEqual(text.value as? String, "5")
         
         // `n + (first * second)` where `second` was set to 7 from ValueView
-        changeSecondButton.tap()
+        changeRequestButton.tap()
         XCTAssertEqual(text.value as? String, "5")
         
         // `n + (first * second)` where `n` was incremented
@@ -172,18 +175,19 @@ class QueryTestsUITests: XCTestCase {
         app.tabs["Tab 1"].tap()
         
         let text = app.staticTexts["binding.value"]
-        let changeSecondButton = app.buttons["binding.button"]
+        let changeRequestButton = app.buttons["binding.changeRequestButton"]
+        let containerChangeRequestButton = app.buttons["container.changeRequestButton"]
         let sharedNotificationButton = app.buttons["shared.notificationButton"]
         
         // `n + (first * second)` where n is zero
         XCTAssertEqual(text.value as? String, "1")
         
         // `n + (first * second)` where `first` was set to 5 from container view
-        app.buttons["Change First"].tap()
+        containerChangeRequestButton.tap()
         XCTAssertEqual(text.value as? String, "5")
         
         // `n + (first * second)` where `second` was set to 7 from ValueView
-        changeSecondButton.tap()
+        changeRequestButton.tap()
         XCTAssertEqual(text.value as? String, "35")
         
         // `n + (first * second)` where `n` was incremented

--- a/Tests/QueryTests/QueryTestsUITests/QueryTestsUITests.swift
+++ b/Tests/QueryTests/QueryTestsUITests/QueryTestsUITests.swift
@@ -19,9 +19,11 @@ class QueryTestsUITests: XCTestCase {
     func testDefaultRequest() throws {
         let app = XCUIApplication()
         app.launch()
+        app.tabs["Tab 1"].tap()
         
         let text = app.staticTexts["default.value"]
         let changeSecondButton = app.buttons["default.button"]
+        let sharedNotificationButton = app.buttons["shared.notificationButton"]
         
         // `n + (first * second)` where n is zero
         XCTAssertEqual(text.value as? String, "6")
@@ -35,7 +37,7 @@ class QueryTestsUITests: XCTestCase {
         XCTAssertEqual(text.value as? String, "14")
         
         // `n + (first * second)` where `n` was incremented
-        app.buttons["Send Test Notification"].tap()
+        sharedNotificationButton.tap()
         XCTAssertEqual(text.value as? String, "15")
         
         // `n + (first * second)` where publisher was reset due to View ID change
@@ -44,12 +46,12 @@ class QueryTestsUITests: XCTestCase {
         
         // Stop publisher subscription
         app.buttons["Toggle Query Observation"].tap()
-        app.buttons["Send Test Notification"].tap()
+        sharedNotificationButton.tap()
         XCTAssertEqual(text.value as? String, "6")
         
         // Restart publisher subscription
         app.buttons["Toggle Query Observation"].tap()
-        app.buttons["Send Test Notification"].tap()
+        sharedNotificationButton.tap()
         XCTAssertEqual(text.value as? String, "7")
     }
     
@@ -59,9 +61,11 @@ class QueryTestsUITests: XCTestCase {
     func testInitialRequest() throws {
         let app = XCUIApplication()
         app.launch()
+        app.tabs["Tab 1"].tap()
         
         let text = app.staticTexts["initial.value"]
         let changeSecondButton = app.buttons["initial.button"]
+        let sharedNotificationButton = app.buttons["shared.notificationButton"]
         
         // `n + (first * second)` where n is zero
         XCTAssertEqual(text.value as? String, "1")
@@ -75,7 +79,7 @@ class QueryTestsUITests: XCTestCase {
         XCTAssertEqual(text.value as? String, "7")
         
         // `n + (first * second)` where `n` was incremented
-        app.buttons["Send Test Notification"].tap()
+        sharedNotificationButton.tap()
         XCTAssertEqual(text.value as? String, "8")
         
         // `n + (first * second)` where publisher was reset due to View ID change
@@ -84,12 +88,12 @@ class QueryTestsUITests: XCTestCase {
         
         // Stop publisher subscription
         app.buttons["Toggle Query Observation"].tap()
-        app.buttons["Send Test Notification"].tap()
+        sharedNotificationButton.tap()
         XCTAssertEqual(text.value as? String, "5")
         
         // Restart publisher subscription
         app.buttons["Toggle Query Observation"].tap()
-        app.buttons["Send Test Notification"].tap()
+        sharedNotificationButton.tap()
         XCTAssertEqual(text.value as? String, "6")
     }
     
@@ -99,9 +103,11 @@ class QueryTestsUITests: XCTestCase {
     func testConstantRequest() throws {
         let app = XCUIApplication()
         app.launch()
+        app.tabs["Tab 1"].tap()
         
         let text = app.staticTexts["constant.value"]
         let changeSecondButton = app.buttons["constant.button"]
+        let sharedNotificationButton = app.buttons["shared.notificationButton"]
         
         // `n + (first * second)` where n is zero
         XCTAssertEqual(text.value as? String, "1")
@@ -115,7 +121,7 @@ class QueryTestsUITests: XCTestCase {
         XCTAssertEqual(text.value as? String, "5")
         
         // `n + (first * second)` where `n` was incremented
-        app.buttons["Send Test Notification"].tap()
+        sharedNotificationButton.tap()
         XCTAssertEqual(text.value as? String, "6")
         
         // `n + (first * second)` where publisher was reset due to View ID change
@@ -124,12 +130,12 @@ class QueryTestsUITests: XCTestCase {
         
         // Stop publisher subscription
         app.buttons["Toggle Query Observation"].tap()
-        app.buttons["Send Test Notification"].tap()
+        sharedNotificationButton.tap()
         XCTAssertEqual(text.value as? String, "5")
         
         // Restart publisher subscription
         app.buttons["Toggle Query Observation"].tap()
-        app.buttons["Send Test Notification"].tap()
+        sharedNotificationButton.tap()
         XCTAssertEqual(text.value as? String, "6")
     }
     
@@ -139,9 +145,11 @@ class QueryTestsUITests: XCTestCase {
     func testBindingRequest() throws {
         let app = XCUIApplication()
         app.launch()
+        app.tabs["Tab 1"].tap()
         
         let text = app.staticTexts["binding.value"]
         let changeSecondButton = app.buttons["binding.button"]
+        let sharedNotificationButton = app.buttons["shared.notificationButton"]
         
         // `n + (first * second)` where n is zero
         XCTAssertEqual(text.value as? String, "1")
@@ -155,7 +163,7 @@ class QueryTestsUITests: XCTestCase {
         XCTAssertEqual(text.value as? String, "35")
         
         // `n + (first * second)` where `n` was incremented
-        app.buttons["Send Test Notification"].tap()
+        sharedNotificationButton.tap()
         XCTAssertEqual(text.value as? String, "36")
         
         // `n + (first * second)` where publisher was reset due to View ID change
@@ -164,13 +172,86 @@ class QueryTestsUITests: XCTestCase {
         
         // Stop publisher subscription
         app.buttons["Toggle Query Observation"].tap()
-        app.buttons["Send Test Notification"].tap()
+        sharedNotificationButton.tap()
         XCTAssertEqual(text.value as? String, "35")
         
         // Restart publisher subscription
         app.buttons["Toggle Query Observation"].tap()
-        app.buttons["Send Test Notification"].tap()
+        sharedNotificationButton.tap()
         XCTAssertEqual(text.value as? String, "36")
+    }
+    
+    func testQueryObservationAlways() {
+        let app = XCUIApplication()
+        app.launch()
+        let text = app.staticTexts["queryObservation.always.value"]
+        let notificationButton = app.buttons["queryObservation.always.notificationButton"]
+        let sharedNotificationButton = app.buttons["shared.notificationButton"]
+        
+        app.tabs["queryObservation.always"].tap()
+        app.tabs["Tab 1"].tap()
+        sharedNotificationButton.tap()
+        
+        app.tabs["queryObservation.always"].tap()
+        XCTAssertEqual(text.value as? String, "7")
+        
+        notificationButton.tap()
+        XCTAssertEqual(text.value as? String, "8")
+        
+        app.tabs["Tab 1"].tap()
+        sharedNotificationButton.tap()
+        
+        app.tabs["queryObservation.always"].tap()
+        XCTAssertEqual(text.value as? String, "9")
+    }
+    
+    func testQueryObservationOnRender() {
+        // TODO: find a way to have a testable difference between onRender and onAppear
+        let app = XCUIApplication()
+        app.launch()
+        let text = app.staticTexts["queryObservation.onRender.value"]
+        let notificationButton = app.buttons["queryObservation.onRender.notificationButton"]
+        let sharedNotificationButton = app.buttons["shared.notificationButton"]
+        
+        app.tabs["queryObservation.onRender"].tap()
+        app.tabs["Tab 1"].tap()
+        sharedNotificationButton.tap()
+        
+        app.tabs["queryObservation.onRender"].tap()
+        XCTAssertEqual(text.value as? String, "6")
+        
+        notificationButton.tap()
+        XCTAssertEqual(text.value as? String, "7")
+        
+        app.tabs["Tab 1"].tap()
+        sharedNotificationButton.tap()
+        
+        app.tabs["queryObservation.onRender"].tap()
+        XCTAssertEqual(text.value as? String, "6")
+    }
+    
+    func testQueryObservationOnAppear() {
+        let app = XCUIApplication()
+        app.launch()
+        let text = app.staticTexts["queryObservation.onAppear.value"]
+        let notificationButton = app.buttons["queryObservation.onAppear.notificationButton"]
+        let sharedNotificationButton = app.buttons["shared.notificationButton"]
+        
+        app.tabs["queryObservation.onAppear"].tap()
+        app.tabs["Tab 1"].tap()
+        sharedNotificationButton.tap()
+        
+        app.tabs["queryObservation.onAppear"].tap()
+        XCTAssertEqual(text.value as? String, "6")
+        
+        notificationButton.tap()
+        XCTAssertEqual(text.value as? String, "7")
+        
+        app.tabs["Tab 1"].tap()
+        sharedNotificationButton.tap()
+        
+        app.tabs["queryObservation.onAppear"].tap()
+        XCTAssertEqual(text.value as? String, "6")
     }
 }
 

--- a/Tests/QueryTests/QueryTestsUITests/QueryTestsUITests.swift
+++ b/Tests/QueryTests/QueryTestsUITests/QueryTestsUITests.swift
@@ -34,11 +34,11 @@ class QueryTestsUITests: XCTestCase {
         // `n + (first * second)` where n is zero
         XCTAssertEqual(text.value as? String, "6")
         
-        // `n + (first * second)` where `first` was changed
+        // `n + (first * second)` where `first` was set to 5 from container view
         app.buttons["Change First"].tap()
         XCTAssertEqual(text.value as? String, "6")
         
-        // `n + (first * second)` where `second` was changed
+        // `n + (first * second)` where `second` was set to 7 from ValueView
         changeSecondButton.tap()
         XCTAssertEqual(text.value as? String, "14")
         
@@ -46,7 +46,7 @@ class QueryTestsUITests: XCTestCase {
         sharedNotificationButton.tap()
         XCTAssertEqual(text.value as? String, "15")
         
-        // `n + (first * second)` where publisher was reset due to View ID change
+        // `n + (first * second)` where publisher was reset due to ValueView ID change
         app.buttons["Change ID"].tap()
         XCTAssertEqual(text.value as? String, "6")
         
@@ -82,11 +82,11 @@ class QueryTestsUITests: XCTestCase {
         // `n + (first * second)` where n is zero
         XCTAssertEqual(text.value as? String, "1")
         
-        // `n + (first * second)` where `first` was changed
+        // `n + (first * second)` where `first` was set to 5 from container view
         app.buttons["Change First"].tap()
         XCTAssertEqual(text.value as? String, "1")
         
-        // `n + (first * second)` where `second` was changed
+        // `n + (first * second)` where `second` was set to 7 from ValueView
         changeSecondButton.tap()
         XCTAssertEqual(text.value as? String, "7")
         
@@ -94,7 +94,7 @@ class QueryTestsUITests: XCTestCase {
         sharedNotificationButton.tap()
         XCTAssertEqual(text.value as? String, "8")
         
-        // `n + (first * second)` where publisher was reset due to View ID change
+        // `n + (first * second)` where publisher was reset due to ValueView ID change
         app.buttons["Change ID"].tap()
         XCTAssertEqual(text.value as? String, "5")
         
@@ -130,11 +130,11 @@ class QueryTestsUITests: XCTestCase {
         // `n + (first * second)` where n is zero
         XCTAssertEqual(text.value as? String, "1")
         
-        // `n + (first * second)` where `first` was changed
+        // `n + (first * second)` where `first` was set to 5 from container view
         app.buttons["Change First"].tap()
         XCTAssertEqual(text.value as? String, "5")
         
-        // `n + (first * second)` where `second` was changed
+        // `n + (first * second)` where `second` was set to 7 from ValueView
         changeSecondButton.tap()
         XCTAssertEqual(text.value as? String, "5")
         
@@ -142,7 +142,7 @@ class QueryTestsUITests: XCTestCase {
         sharedNotificationButton.tap()
         XCTAssertEqual(text.value as? String, "6")
         
-        // `n + (first * second)` where publisher was reset due to View ID change
+        // `n + (first * second)` where publisher was reset due to ValueView ID change
         app.buttons["Change ID"].tap()
         XCTAssertEqual(text.value as? String, "5")
         
@@ -178,11 +178,11 @@ class QueryTestsUITests: XCTestCase {
         // `n + (first * second)` where n is zero
         XCTAssertEqual(text.value as? String, "1")
         
-        // `n + (first * second)` where `first` was changed
+        // `n + (first * second)` where `first` was set to 5 from container view
         app.buttons["Change First"].tap()
         XCTAssertEqual(text.value as? String, "5")
         
-        // `n + (first * second)` where `second` was changed
+        // `n + (first * second)` where `second` was set to 7 from ValueView
         changeSecondButton.tap()
         XCTAssertEqual(text.value as? String, "35")
         
@@ -190,7 +190,7 @@ class QueryTestsUITests: XCTestCase {
         sharedNotificationButton.tap()
         XCTAssertEqual(text.value as? String, "36")
         
-        // `n + (first * second)` where publisher was reset due to View ID change
+        // `n + (first * second)` where publisher was reset due to ValueView ID change
         app.buttons["Change ID"].tap()
         XCTAssertEqual(text.value as? String, "35")
         

--- a/Tests/QueryTests/QueryTestsUITests/QueryTestsUITests.swift
+++ b/Tests/QueryTests/QueryTestsUITests/QueryTestsUITests.swift
@@ -19,6 +19,12 @@ class QueryTestsUITests: XCTestCase {
     func testDefaultRequest() throws {
         let app = XCUIApplication()
         app.launch()
+        
+        // Make sure all ui elements are hittable
+        XCUIElement.perform(withKeyModifiers: .option) {
+            app.buttons[XCUIIdentifierFullScreenWindow].tap()
+        }
+        
         app.tabs["Tab 1"].tap()
         
         let text = app.staticTexts["default.value"]
@@ -61,6 +67,12 @@ class QueryTestsUITests: XCTestCase {
     func testInitialRequest() throws {
         let app = XCUIApplication()
         app.launch()
+        
+        // Make sure all ui elements are hittable
+        XCUIElement.perform(withKeyModifiers: .option) {
+            app.buttons[XCUIIdentifierFullScreenWindow].tap()
+        }
+        
         app.tabs["Tab 1"].tap()
         
         let text = app.staticTexts["initial.value"]
@@ -103,6 +115,12 @@ class QueryTestsUITests: XCTestCase {
     func testConstantRequest() throws {
         let app = XCUIApplication()
         app.launch()
+        
+        // Make sure all ui elements are hittable
+        XCUIElement.perform(withKeyModifiers: .option) {
+            app.buttons[XCUIIdentifierFullScreenWindow].tap()
+        }
+        
         app.tabs["Tab 1"].tap()
         
         let text = app.staticTexts["constant.value"]
@@ -145,6 +163,12 @@ class QueryTestsUITests: XCTestCase {
     func testBindingRequest() throws {
         let app = XCUIApplication()
         app.launch()
+        
+        // Make sure all ui elements are hittable
+        XCUIElement.perform(withKeyModifiers: .option) {
+            app.buttons[XCUIIdentifierFullScreenWindow].tap()
+        }
+        
         app.tabs["Tab 1"].tap()
         
         let text = app.staticTexts["binding.value"]
@@ -184,6 +208,12 @@ class QueryTestsUITests: XCTestCase {
     func testQueryObservationAlways() {
         let app = XCUIApplication()
         app.launch()
+        
+        // Make sure all ui elements are hittable
+        XCUIElement.perform(withKeyModifiers: .option) {
+            app.buttons[XCUIIdentifierFullScreenWindow].tap()
+        }
+        
         let text = app.staticTexts["queryObservation.always.value"]
         let notificationButton = app.buttons["queryObservation.always.notificationButton"]
         let sharedNotificationButton = app.buttons["shared.notificationButton"]
@@ -209,6 +239,12 @@ class QueryTestsUITests: XCTestCase {
         // TODO: find a way to have a testable difference between onRender and onAppear
         let app = XCUIApplication()
         app.launch()
+        
+        // Make sure all ui elements are hittable
+        XCUIElement.perform(withKeyModifiers: .option) {
+            app.buttons[XCUIIdentifierFullScreenWindow].tap()
+        }
+        
         let text = app.staticTexts["queryObservation.onRender.value"]
         let notificationButton = app.buttons["queryObservation.onRender.notificationButton"]
         let sharedNotificationButton = app.buttons["shared.notificationButton"]
@@ -233,6 +269,12 @@ class QueryTestsUITests: XCTestCase {
     func testQueryObservationOnAppear() {
         let app = XCUIApplication()
         app.launch()
+        
+        // Make sure all ui elements are hittable
+        XCUIElement.perform(withKeyModifiers: .option) {
+            app.buttons[XCUIIdentifierFullScreenWindow].tap()
+        }
+        
         let text = app.staticTexts["queryObservation.onAppear.value"]
         let notificationButton = app.buttons["queryObservation.onAppear.notificationButton"]
         let sharedNotificationButton = app.buttons["shared.notificationButton"]
@@ -252,14 +294,5 @@ class QueryTestsUITests: XCTestCase {
         
         app.tabs["queryObservation.onAppear"].tap()
         XCTAssertEqual(text.value as? String, "6")
-    }
-}
-
-extension Array {
-    mutating func popFirst() -> Element? {
-        if isEmpty {
-            return nil
-        }
-        return removeFirst()
     }
 }


### PR DESCRIPTION
This pull request brings tests for all `@Query` initializers, the `\.queryObservationEnabled` environment key, and `QueryObservation`. I did not find a way to make a test that reveals the differences between `QueryObservation.onAppear` from `.onRender`, but we're pretty much covered.