### PR TITLE
Bump OS dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,10 +6,10 @@ import PackageDescription
 let package = Package(
     name: "GRDBQuery",
     platforms: [
-        .iOS(.v13),
-        .macOS(.v10_15),
-        .tvOS(.v13),
-        .watchOS(.v6),
+        .iOS(.v14),
+        .macOS(.v11),
+        .tvOS(.v14),
+        .watchOS(.v7),
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.


### PR DESCRIPTION
This PR bumps the package dependencies, so that it reflects the real availability of `@StateObject` that Apple has recently fixed in Xcode 14.3 beta: iOS 14.0+, macOS 11.0+, tvOS 14.0+, watchOS 7.0+.

Fixes #36.
