### PR TITLE
@‍EnvironmentState and support for the Observable macro

### DIFF
--- a/Documentation/ObservableDemo/ObservableDemo.xcodeproj/project.pbxproj
+++ b/Documentation/ObservableDemo/ObservableDemo.xcodeproj/project.pbxproj
@@ -1,0 +1,729 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		564B80502A7E84360002DF51 /* ObservableDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564B804F2A7E84360002DF51 /* ObservableDemoApp.swift */; };
+		564B80542A7E84380002DF51 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 564B80532A7E84380002DF51 /* Assets.xcassets */; };
+		564B80572A7E84380002DF51 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 564B80562A7E84380002DF51 /* Preview Assets.xcassets */; };
+		564B80612A7E84380002DF51 /* ObservableDemoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564B80602A7E84380002DF51 /* ObservableDemoTests.swift */; };
+		564B806B2A7E84380002DF51 /* ObservableDemoUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564B806A2A7E84380002DF51 /* ObservableDemoUITests.swift */; };
+		564B806D2A7E84380002DF51 /* ObservableDemoUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564B806C2A7E84380002DF51 /* ObservableDemoUITestsLaunchTests.swift */; };
+		564B807B2A7E84780002DF51 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = 564B807A2A7E84780002DF51 /* GRDB */; };
+		564B80812A7E84F80002DF51 /* GRDBQuery in Frameworks */ = {isa = PBXBuildFile; productRef = 564B80802A7E84F80002DF51 /* GRDBQuery */; };
+		564B80832A7E84F80002DF51 /* Players in Frameworks */ = {isa = PBXBuildFile; productRef = 564B80822A7E84F80002DF51 /* Players */; };
+		564B80872A7E85460002DF51 /* PlayerRepository+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564B80842A7E85460002DF51 /* PlayerRepository+App.swift */; };
+		564B80882A7E85460002DF51 /* PlayerRepository+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564B80852A7E85460002DF51 /* PlayerRepository+SwiftUI.swift */; };
+		564B80892A7E85460002DF51 /* Player+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564B80862A7E85460002DF51 /* Player+App.swift */; };
+		564B80982A7E85670002DF51 /* InformationStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564B808B2A7E85670002DF51 /* InformationStyle.swift */; };
+		564B80992A7E85670002DF51 /* PlayerFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564B808D2A7E85670002DF51 /* PlayerFormView.swift */; };
+		564B809A2A7E85670002DF51 /* PlayerFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564B808E2A7E85670002DF51 /* PlayerFormViewModel.swift */; };
+		564B809B2A7E85670002DF51 /* PlayerNotFoundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564B808F2A7E85670002DF51 /* PlayerNotFoundView.swift */; };
+		564B809C2A7E85670002DF51 /* PlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564B80902A7E85670002DF51 /* PlayerView.swift */; };
+		564B809D2A7E85670002DF51 /* PlayerEditionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564B80922A7E85670002DF51 /* PlayerEditionView.swift */; };
+		564B809E2A7E85670002DF51 /* PlayerEditionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564B80932A7E85670002DF51 /* PlayerEditionViewModel.swift */; };
+		564B809F2A7E85670002DF51 /* AppView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564B80952A7E85670002DF51 /* AppView.swift */; };
+		564B80A02A7E85670002DF51 /* AppViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564B80962A7E85670002DF51 /* AppViewModel.swift */; };
+		564B80A12A7E85670002DF51 /* DatabaseButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564B80972A7E85670002DF51 /* DatabaseButtons.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		564B805D2A7E84380002DF51 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 564B80442A7E84360002DF51 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 564B804B2A7E84360002DF51;
+			remoteInfo = ObservableDemo;
+		};
+		564B80672A7E84380002DF51 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 564B80442A7E84360002DF51 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 564B804B2A7E84360002DF51;
+			remoteInfo = ObservableDemo;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		564B804C2A7E84360002DF51 /* ObservableDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ObservableDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		564B804F2A7E84360002DF51 /* ObservableDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableDemoApp.swift; sourceTree = "<group>"; };
+		564B80532A7E84380002DF51 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		564B80562A7E84380002DF51 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		564B805C2A7E84380002DF51 /* ObservableDemoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ObservableDemoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		564B80602A7E84380002DF51 /* ObservableDemoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableDemoTests.swift; sourceTree = "<group>"; };
+		564B80662A7E84380002DF51 /* ObservableDemoUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ObservableDemoUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		564B806A2A7E84380002DF51 /* ObservableDemoUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableDemoUITests.swift; sourceTree = "<group>"; };
+		564B806C2A7E84380002DF51 /* ObservableDemoUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableDemoUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		564B807D2A7E84AA0002DF51 /* GRDBQuery */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = GRDBQuery; path = ../../..; sourceTree = "<group>"; };
+		564B807E2A7E84B20002DF51 /* Players */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = Players; path = ../../Players; sourceTree = "<group>"; };
+		564B80842A7E85460002DF51 /* PlayerRepository+App.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PlayerRepository+App.swift"; sourceTree = "<group>"; };
+		564B80852A7E85460002DF51 /* PlayerRepository+SwiftUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PlayerRepository+SwiftUI.swift"; sourceTree = "<group>"; };
+		564B80862A7E85460002DF51 /* Player+App.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Player+App.swift"; sourceTree = "<group>"; };
+		564B808B2A7E85670002DF51 /* InformationStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InformationStyle.swift; sourceTree = "<group>"; };
+		564B808D2A7E85670002DF51 /* PlayerFormView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlayerFormView.swift; sourceTree = "<group>"; };
+		564B808E2A7E85670002DF51 /* PlayerFormViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlayerFormViewModel.swift; sourceTree = "<group>"; };
+		564B808F2A7E85670002DF51 /* PlayerNotFoundView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlayerNotFoundView.swift; sourceTree = "<group>"; };
+		564B80902A7E85670002DF51 /* PlayerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlayerView.swift; sourceTree = "<group>"; };
+		564B80922A7E85670002DF51 /* PlayerEditionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlayerEditionView.swift; sourceTree = "<group>"; };
+		564B80932A7E85670002DF51 /* PlayerEditionViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlayerEditionViewModel.swift; sourceTree = "<group>"; };
+		564B80952A7E85670002DF51 /* AppView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppView.swift; sourceTree = "<group>"; };
+		564B80962A7E85670002DF51 /* AppViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppViewModel.swift; sourceTree = "<group>"; };
+		564B80972A7E85670002DF51 /* DatabaseButtons.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseButtons.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		564B80492A7E84360002DF51 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				564B80832A7E84F80002DF51 /* Players in Frameworks */,
+				564B80812A7E84F80002DF51 /* GRDBQuery in Frameworks */,
+				564B807B2A7E84780002DF51 /* GRDB in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		564B80592A7E84380002DF51 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		564B80632A7E84380002DF51 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		564B80432A7E84360002DF51 = {
+			isa = PBXGroup;
+			children = (
+				564B804E2A7E84360002DF51 /* ObservableDemo */,
+				564B805F2A7E84380002DF51 /* ObservableDemoTests */,
+				564B80692A7E84380002DF51 /* ObservableDemoUITests */,
+				564B804D2A7E84360002DF51 /* Products */,
+				564B807C2A7E849D0002DF51 /* Packages */,
+				564B807F2A7E84F80002DF51 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		564B804D2A7E84360002DF51 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				564B804C2A7E84360002DF51 /* ObservableDemo.app */,
+				564B805C2A7E84380002DF51 /* ObservableDemoTests.xctest */,
+				564B80662A7E84380002DF51 /* ObservableDemoUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		564B804E2A7E84360002DF51 /* ObservableDemo */ = {
+			isa = PBXGroup;
+			children = (
+				564B804F2A7E84360002DF51 /* ObservableDemoApp.swift */,
+				564B80862A7E85460002DF51 /* Player+App.swift */,
+				564B80842A7E85460002DF51 /* PlayerRepository+App.swift */,
+				564B80852A7E85460002DF51 /* PlayerRepository+SwiftUI.swift */,
+				564B808A2A7E85670002DF51 /* Views */,
+				564B80532A7E84380002DF51 /* Assets.xcassets */,
+				564B80552A7E84380002DF51 /* Preview Content */,
+			);
+			path = ObservableDemo;
+			sourceTree = "<group>";
+		};
+		564B80552A7E84380002DF51 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				564B80562A7E84380002DF51 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		564B805F2A7E84380002DF51 /* ObservableDemoTests */ = {
+			isa = PBXGroup;
+			children = (
+				564B80602A7E84380002DF51 /* ObservableDemoTests.swift */,
+			);
+			path = ObservableDemoTests;
+			sourceTree = "<group>";
+		};
+		564B80692A7E84380002DF51 /* ObservableDemoUITests */ = {
+			isa = PBXGroup;
+			children = (
+				564B806A2A7E84380002DF51 /* ObservableDemoUITests.swift */,
+				564B806C2A7E84380002DF51 /* ObservableDemoUITestsLaunchTests.swift */,
+			);
+			path = ObservableDemoUITests;
+			sourceTree = "<group>";
+		};
+		564B807C2A7E849D0002DF51 /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				564B807D2A7E84AA0002DF51 /* GRDBQuery */,
+				564B807E2A7E84B20002DF51 /* Players */,
+			);
+			name = Packages;
+			path = ObservableDemo;
+			sourceTree = "<group>";
+		};
+		564B807F2A7E84F80002DF51 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		564B808A2A7E85670002DF51 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				564B80942A7E85670002DF51 /* AppView */,
+				564B80972A7E85670002DF51 /* DatabaseButtons.swift */,
+				564B808B2A7E85670002DF51 /* InformationStyle.swift */,
+				564B80912A7E85670002DF51 /* PlayerEditionView */,
+				564B808C2A7E85670002DF51 /* PlayerFormView */,
+				564B808F2A7E85670002DF51 /* PlayerNotFoundView.swift */,
+				564B80902A7E85670002DF51 /* PlayerView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		564B808C2A7E85670002DF51 /* PlayerFormView */ = {
+			isa = PBXGroup;
+			children = (
+				564B808D2A7E85670002DF51 /* PlayerFormView.swift */,
+				564B808E2A7E85670002DF51 /* PlayerFormViewModel.swift */,
+			);
+			path = PlayerFormView;
+			sourceTree = "<group>";
+		};
+		564B80912A7E85670002DF51 /* PlayerEditionView */ = {
+			isa = PBXGroup;
+			children = (
+				564B80922A7E85670002DF51 /* PlayerEditionView.swift */,
+				564B80932A7E85670002DF51 /* PlayerEditionViewModel.swift */,
+			);
+			path = PlayerEditionView;
+			sourceTree = "<group>";
+		};
+		564B80942A7E85670002DF51 /* AppView */ = {
+			isa = PBXGroup;
+			children = (
+				564B80952A7E85670002DF51 /* AppView.swift */,
+				564B80962A7E85670002DF51 /* AppViewModel.swift */,
+			);
+			path = AppView;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		564B804B2A7E84360002DF51 /* ObservableDemo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 564B80702A7E84380002DF51 /* Build configuration list for PBXNativeTarget "ObservableDemo" */;
+			buildPhases = (
+				564B80482A7E84360002DF51 /* Sources */,
+				564B80492A7E84360002DF51 /* Frameworks */,
+				564B804A2A7E84360002DF51 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ObservableDemo;
+			packageProductDependencies = (
+				564B807A2A7E84780002DF51 /* GRDB */,
+				564B80802A7E84F80002DF51 /* GRDBQuery */,
+				564B80822A7E84F80002DF51 /* Players */,
+			);
+			productName = ObservableDemo;
+			productReference = 564B804C2A7E84360002DF51 /* ObservableDemo.app */;
+			productType = "com.apple.product-type.application";
+		};
+		564B805B2A7E84380002DF51 /* ObservableDemoTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 564B80732A7E84380002DF51 /* Build configuration list for PBXNativeTarget "ObservableDemoTests" */;
+			buildPhases = (
+				564B80582A7E84380002DF51 /* Sources */,
+				564B80592A7E84380002DF51 /* Frameworks */,
+				564B805A2A7E84380002DF51 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				564B805E2A7E84380002DF51 /* PBXTargetDependency */,
+			);
+			name = ObservableDemoTests;
+			productName = ObservableDemoTests;
+			productReference = 564B805C2A7E84380002DF51 /* ObservableDemoTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		564B80652A7E84380002DF51 /* ObservableDemoUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 564B80762A7E84380002DF51 /* Build configuration list for PBXNativeTarget "ObservableDemoUITests" */;
+			buildPhases = (
+				564B80622A7E84380002DF51 /* Sources */,
+				564B80632A7E84380002DF51 /* Frameworks */,
+				564B80642A7E84380002DF51 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				564B80682A7E84380002DF51 /* PBXTargetDependency */,
+			);
+			name = ObservableDemoUITests;
+			productName = ObservableDemoUITests;
+			productReference = 564B80662A7E84380002DF51 /* ObservableDemoUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		564B80442A7E84360002DF51 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					564B804B2A7E84360002DF51 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+					564B805B2A7E84380002DF51 = {
+						CreatedOnToolsVersion = 15.0;
+						TestTargetID = 564B804B2A7E84360002DF51;
+					};
+					564B80652A7E84380002DF51 = {
+						CreatedOnToolsVersion = 15.0;
+						TestTargetID = 564B804B2A7E84360002DF51;
+					};
+				};
+			};
+			buildConfigurationList = 564B80472A7E84360002DF51 /* Build configuration list for PBXProject "ObservableDemo" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 564B80432A7E84360002DF51;
+			packageReferences = (
+				564B80792A7E84780002DF51 /* XCRemoteSwiftPackageReference "GRDB.swift" */,
+			);
+			productRefGroup = 564B804D2A7E84360002DF51 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				564B804B2A7E84360002DF51 /* ObservableDemo */,
+				564B805B2A7E84380002DF51 /* ObservableDemoTests */,
+				564B80652A7E84380002DF51 /* ObservableDemoUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		564B804A2A7E84360002DF51 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				564B80572A7E84380002DF51 /* Preview Assets.xcassets in Resources */,
+				564B80542A7E84380002DF51 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		564B805A2A7E84380002DF51 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		564B80642A7E84380002DF51 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		564B80482A7E84360002DF51 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				564B809C2A7E85670002DF51 /* PlayerView.swift in Sources */,
+				564B809B2A7E85670002DF51 /* PlayerNotFoundView.swift in Sources */,
+				564B809A2A7E85670002DF51 /* PlayerFormViewModel.swift in Sources */,
+				564B80A02A7E85670002DF51 /* AppViewModel.swift in Sources */,
+				564B80882A7E85460002DF51 /* PlayerRepository+SwiftUI.swift in Sources */,
+				564B80982A7E85670002DF51 /* InformationStyle.swift in Sources */,
+				564B80502A7E84360002DF51 /* ObservableDemoApp.swift in Sources */,
+				564B809D2A7E85670002DF51 /* PlayerEditionView.swift in Sources */,
+				564B80A12A7E85670002DF51 /* DatabaseButtons.swift in Sources */,
+				564B80892A7E85460002DF51 /* Player+App.swift in Sources */,
+				564B809F2A7E85670002DF51 /* AppView.swift in Sources */,
+				564B80872A7E85460002DF51 /* PlayerRepository+App.swift in Sources */,
+				564B80992A7E85670002DF51 /* PlayerFormView.swift in Sources */,
+				564B809E2A7E85670002DF51 /* PlayerEditionViewModel.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		564B80582A7E84380002DF51 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				564B80612A7E84380002DF51 /* ObservableDemoTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		564B80622A7E84380002DF51 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				564B806D2A7E84380002DF51 /* ObservableDemoUITestsLaunchTests.swift in Sources */,
+				564B806B2A7E84380002DF51 /* ObservableDemoUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		564B805E2A7E84380002DF51 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 564B804B2A7E84360002DF51 /* ObservableDemo */;
+			targetProxy = 564B805D2A7E84380002DF51 /* PBXContainerItemProxy */;
+		};
+		564B80682A7E84380002DF51 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 564B804B2A7E84360002DF51 /* ObservableDemo */;
+			targetProxy = 564B80672A7E84380002DF51 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		564B806E2A7E84380002DF51 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		564B806F2A7E84380002DF51 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		564B80712A7E84380002DF51 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"ObservableDemo/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.github.groue.ObservableDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		564B80722A7E84380002DF51 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"ObservableDemo/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.github.groue.ObservableDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		564B80742A7E84380002DF51 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.github.groue.ObservableDemoTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ObservableDemo.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ObservableDemo";
+			};
+			name = Debug;
+		};
+		564B80752A7E84380002DF51 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.github.groue.ObservableDemoTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ObservableDemo.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ObservableDemo";
+			};
+			name = Release;
+		};
+		564B80772A7E84380002DF51 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.github.groue.ObservableDemoUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = ObservableDemo;
+			};
+			name = Debug;
+		};
+		564B80782A7E84380002DF51 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.github.groue.ObservableDemoUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = ObservableDemo;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		564B80472A7E84360002DF51 /* Build configuration list for PBXProject "ObservableDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				564B806E2A7E84380002DF51 /* Debug */,
+				564B806F2A7E84380002DF51 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		564B80702A7E84380002DF51 /* Build configuration list for PBXNativeTarget "ObservableDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				564B80712A7E84380002DF51 /* Debug */,
+				564B80722A7E84380002DF51 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		564B80732A7E84380002DF51 /* Build configuration list for PBXNativeTarget "ObservableDemoTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				564B80742A7E84380002DF51 /* Debug */,
+				564B80752A7E84380002DF51 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		564B80762A7E84380002DF51 /* Build configuration list for PBXNativeTarget "ObservableDemoUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				564B80772A7E84380002DF51 /* Debug */,
+				564B80782A7E84380002DF51 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		564B80792A7E84780002DF51 /* XCRemoteSwiftPackageReference "GRDB.swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/groue/GRDB.swift.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 6.16.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		564B807A2A7E84780002DF51 /* GRDB */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 564B80792A7E84780002DF51 /* XCRemoteSwiftPackageReference "GRDB.swift" */;
+			productName = GRDB;
+		};
+		564B80802A7E84F80002DF51 /* GRDBQuery */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = GRDBQuery;
+		};
+		564B80822A7E84F80002DF51 /* Players */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Players;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 564B80442A7E84360002DF51 /* Project object */;
+}

--- a/Documentation/ObservableDemo/ObservableDemo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Documentation/ObservableDemo/ObservableDemo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Documentation/ObservableDemo/ObservableDemo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Documentation/ObservableDemo/ObservableDemo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Documentation/ObservableDemo/ObservableDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Documentation/ObservableDemo/ObservableDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/GRDB.swift.git",
       "state" : {
-        "revision" : "2d19cab2b525f885ee8d7efec96093431f6b5f20",
-        "version" : "6.10.0"
+        "revision" : "e83f3eb25ef4d5a36a13dbee98f8ac67e24e5c8f",
+        "version" : "6.16.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",
       "state" : {
-        "revision" : "9b1258905c21fc1b97bf03d1b4ca12c4ec4e5fda",
-        "version" : "1.2.0"
+        "revision" : "26ac5758409154cc448d7ab82389c520fa8a8247",
+        "version" : "1.3.0"
       }
     },
     {

--- a/Documentation/ObservableDemo/ObservableDemo/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Documentation/ObservableDemo/ObservableDemo/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Documentation/ObservableDemo/ObservableDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Documentation/ObservableDemo/ObservableDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Documentation/ObservableDemo/ObservableDemo/Assets.xcassets/Contents.json
+++ b/Documentation/ObservableDemo/ObservableDemo/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Documentation/ObservableDemo/ObservableDemo/ObservableDemoApp.swift
+++ b/Documentation/ObservableDemo/ObservableDemo/ObservableDemoApp.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+@main
+struct ObservableDemoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            AppView()
+                // Use the on-disk repository in the application
+                .environment(\.playerRepository, .shared)
+        }
+    }
+}

--- a/Documentation/ObservableDemo/ObservableDemo/Player+App.swift
+++ b/Documentation/ObservableDemo/ObservableDemo/Player+App.swift
@@ -1,0 +1,27 @@
+import Players
+
+// Convenience `Player` methods for the app.
+extension Player {
+    private static let names = [
+        "Arthur", "Anita", "Barbara", "Bernard", "Craig", "Chiara", "David",
+        "Dean", "Éric", "Elena", "Fatima", "Frederik", "Gilbert", "Georgette",
+        "Henriette", "Hassan", "Ignacio", "Irene", "Julie", "Jack", "Karl",
+        "Kristel", "Louis", "Liz", "Masashi", "Mary", "Noam", "Nicole",
+        "Ophelie", "Oleg", "Pascal", "Patricia", "Quentin", "Quinn", "Raoul",
+        "Rachel", "Stephan", "Susie", "Tristan", "Tatiana", "Ursule", "Urbain",
+        "Victor", "Violette", "Wilfried", "Wilhelmina", "Yvon", "Yann",
+        "Zazie", "Zoé"]
+    
+    /// Creates a new player with random name and random score
+    static func makeRandom(id: Int64? = nil) -> Player {
+        Player(
+            id: id,
+            name: names.randomElement()!,
+            score: 10 * Int.random(in: 0...100),
+            photoID: Int.random(in: 0...1000))
+    }
+    
+    /// A placeholder Player
+    static let placeholder = Player(name: "xxxxxx", score: 100, photoID: 1)
+}
+

--- a/Documentation/ObservableDemo/ObservableDemo/PlayerRepository+App.swift
+++ b/Documentation/ObservableDemo/ObservableDemo/PlayerRepository+App.swift
@@ -1,0 +1,65 @@
+import Foundation
+import GRDB
+import Players
+
+// A `PlayerRepository` extension for creating various repositories for the
+// app, tests, and previews.
+extension PlayerRepository {
+    /// The on-disk repository for the application.
+    static let shared = makeShared()
+    
+    /// Returns an on-disk repository for the application.
+    private static func makeShared() -> PlayerRepository {
+        do {
+            // Apply recommendations from
+            // <https://swiftpackageindex.com/groue/grdb.swift/documentation/grdb/databaseconnections>
+            //
+            // Create the "Application Support/Database" directory if needed
+            let fileManager = FileManager.default
+            let appSupportURL = try fileManager.url(
+                for: .applicationSupportDirectory, in: .userDomainMask,
+                appropriateFor: nil, create: true)
+            let directoryURL = appSupportURL.appendingPathComponent("Database", isDirectory: true)
+            try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+
+            // Open or create the database
+            let databaseURL = directoryURL.appendingPathComponent("db.sqlite")
+            NSLog("Database stored at \(databaseURL.path)")
+            let dbPool = try DatabasePool(
+                path: databaseURL.path,
+                // Use default PlayerRepository configuration
+                configuration: PlayerRepository.makeConfiguration())
+
+            // Create the PlayerRepository
+            let playerRepository = try PlayerRepository(dbPool)
+            
+            return playerRepository
+        } catch {
+            // Replace this implementation with code to handle the error appropriately.
+            // fatalError() causes the application to generate a crash log and terminate.
+            //
+            // Typical reasons for an error here include:
+            // * The parent directory cannot be created, or disallows writing.
+            // * The database is not accessible, due to permissions or data protection when the device is locked.
+            // * The device is out of space.
+            // * The database could not be migrated to its latest schema version.
+            // Check the error message to determine what the actual problem was.
+            fatalError("Unresolved error \(error)")
+        }
+    }
+    
+    /// Returns an empty in-memory repository, for previews and tests.
+    static func empty() -> PlayerRepository {
+        try! PlayerRepository(DatabaseQueue(configuration: PlayerRepository.makeConfiguration()))
+    }
+    
+    /// Returns an in-memory repository that contains one player,
+    /// for previews and tests.
+    ///
+    /// - parameter playerId: The ID of the inserted player.
+    static func populated(playerId: Int64? = nil) -> PlayerRepository {
+        let repo = self.empty()
+        _ = try! repo.insert(Player.makeRandom(id: playerId))
+        return repo
+    }
+}

--- a/Documentation/ObservableDemo/ObservableDemo/PlayerRepository+SwiftUI.swift
+++ b/Documentation/ObservableDemo/ObservableDemo/PlayerRepository+SwiftUI.swift
@@ -1,0 +1,33 @@
+import GRDBQuery
+import Players
+import SwiftUI
+
+// MARK: - Give SwiftUI access to the player repository
+
+// Define a new environment key that grants access to a `PlayerRepository`.
+//
+// The technique is documented at
+// <https://developer.apple.com/documentation/swiftui/environmentkey>.
+private struct PlayerRepositoryKey: EnvironmentKey {
+    /// The default appDatabase is an empty in-memory repository.
+    static let defaultValue = PlayerRepository.empty()
+}
+
+extension EnvironmentValues {
+    var playerRepository: PlayerRepository {
+        get { self[PlayerRepositoryKey.self] }
+        set { self[PlayerRepositoryKey.self] = newValue }
+    }
+}
+
+// MARK: - @Query convenience
+
+// Help views and previews observe the database with the @Query property wrapper.
+// See <https://swiftpackageindex.com/groue/grdbquery/documentation/grdbquery/gettingstarted>
+extension Query where Request.DatabaseContext == PlayerRepository {
+    /// Creates a `Query`, given an initial `Queryable` request that
+    /// uses `PlayerRepository` as a `DatabaseContext`.
+    init(_ request: Request) {
+        self.init(request, in: \.playerRepository)
+    }
+}

--- a/Documentation/ObservableDemo/ObservableDemo/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Documentation/ObservableDemo/ObservableDemo/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Documentation/ObservableDemo/ObservableDemo/Views/AppView/AppView.swift
+++ b/Documentation/ObservableDemo/ObservableDemo/Views/AppView/AppView.swift
@@ -1,0 +1,81 @@
+import GRDBQuery
+import SwiftUI
+
+/// The main application view
+struct AppView: View {
+    @EnvironmentState private var viewModel: AppViewModel
+    
+    init() {
+        _viewModel = EnvironmentState {
+            AppViewModel(playerRepository: $0.playerRepository)
+        }
+    }
+    
+    var body: some View {
+        NavigationView {
+            VStack {
+                if let player = viewModel.player {
+                    PlayerView(player: player, editAction: viewModel.editPlayer)
+                        .padding(.vertical)
+                    
+                    Spacer()
+                    populatedFooter()
+                } else {
+                    PlayerView(player: .placeholder)
+                        .padding(.vertical)
+                        .redacted(reason: .placeholder)
+                    
+                    Spacer()
+                    emptyFooter()
+                }
+            }
+            .padding(.horizontal)
+            .sheet(item: $viewModel.editedPlayer) { editedPlayer in
+                PlayerEditionView(id: editedPlayer.id)
+            }
+            .navigationTitle("MVVM Demo")
+        }
+    }
+    
+    private func emptyFooter() -> some View {
+        VStack {
+            Text("The demo application observes the database and displays information about the player.")
+                .informationStyle()
+            
+            CreatePlayerButton("Create a Player")
+        }
+        .informationBox()
+    }
+    
+    private func populatedFooter() -> some View {
+        VStack(spacing: 10) {
+            Text("What if another application component deletes the player at the most unexpected moment?")
+                .informationStyle()
+            DeletePlayersButton("Delete Player")
+            
+            Spacer().frame(height: 10)
+            Text("What if the player is deleted soon after the Edit button is hit?")
+                .informationStyle()
+            DeletePlayersButton("Delete After Editing", after: {
+                viewModel.editPlayer()
+            })
+            
+            Spacer().frame(height: 10)
+            Text("What if the player is deleted right before the Edit button is hit?")
+                .informationStyle()
+            DeletePlayersButton("Delete Before Editing", before: {
+                viewModel.editPlayer()
+            })
+        }
+        .informationBox()
+    }
+}
+
+struct AppView_Previews: PreviewProvider {
+    static var previews: some View {
+        AppView().environment(\.playerRepository, .empty())
+            .previewDisplayName("Database Initially Empty")
+        AppView().environment(\.playerRepository, .populated())
+            .previewDisplayName("Database Initially Populated")
+    }
+}

--- a/Documentation/ObservableDemo/ObservableDemo/Views/AppView/AppViewModel.swift
+++ b/Documentation/ObservableDemo/ObservableDemo/Views/AppView/AppViewModel.swift
@@ -1,0 +1,44 @@
+import Combine
+import Observation
+import GRDB
+import Players
+
+/// The view model for ``AppView``.
+@Observable
+final class AppViewModel {
+    /// An `Identifiable` wrapper for a player id, able to be used as an
+    /// item in SwiftUI `sheet(item:onDismiss:content:)`.
+    struct EditedPlayerID: Identifiable {
+        let id: Int64
+        
+        fileprivate init(id: Int64) {
+            self.id = id
+        }
+    }
+    
+    /// The player to display.
+    private(set) var player: Player?
+    
+    /// The id of the player to edit.
+    var editedPlayer: EditedPlayerID?
+    
+    private var observationCancellable: AnyCancellable?
+    
+    init(playerRepository: PlayerRepository) {
+        observationCancellable = ValueObservation
+            .tracking(Player.fetchOne)
+            .publisher(in: playerRepository.reader, scheduling: .immediate)
+            .sink(
+                receiveCompletion: { _ in /* ignore error */ },
+                receiveValue: { [weak self] player in
+                    self?.player = player
+                })
+    }
+    
+    /// Start editing the player.
+    func editPlayer() {
+        if let id = player?.id {
+            editedPlayer = EditedPlayerID(id: id)
+        }
+    }
+}

--- a/Documentation/ObservableDemo/ObservableDemo/Views/DatabaseButtons.swift
+++ b/Documentation/ObservableDemo/ObservableDemo/Views/DatabaseButtons.swift
@@ -1,0 +1,114 @@
+import Players
+import SwiftUI
+
+/// A helper button that creates players in the database
+struct CreatePlayerButton: View {
+    @Environment(\.playerRepository) private var playerRepository
+    private var titleKey: LocalizedStringKey
+    
+    init(_ titleKey: LocalizedStringKey) {
+        self.titleKey = titleKey
+    }
+    
+    var body: some View {
+        Button {
+            _ = try! playerRepository.insert(Player.makeRandom())
+        } label: {
+            Label(titleKey, systemImage: "plus")
+        }
+    }
+}
+
+/// A helper button that deletes players in the database
+struct DeletePlayersButton: View {
+    private enum Mode {
+        case delete
+        case deleteAfter(() -> Void)
+        case deleteBefore(() -> Void)
+    }
+    
+    @Environment(\.playerRepository) private var playerRepository
+    private var titleKey: LocalizedStringKey
+    private var mode: Mode
+    
+    /// Creates a button that simply deletes players.
+    init(_ titleKey: LocalizedStringKey) {
+        self.titleKey = titleKey
+        self.mode = .delete
+    }
+    
+    /// Creates a button that deletes players soon after performing `action`.
+    init(
+        _ titleKey: LocalizedStringKey,
+        after action: @escaping () -> Void)
+    {
+        self.titleKey = titleKey
+        self.mode = .deleteAfter(action)
+    }
+    
+    /// Creates a button that deletes players immediately after performing `action`.
+    init(
+        _ titleKey: LocalizedStringKey,
+        before action: @escaping () -> Void)
+    {
+        self.titleKey = titleKey
+        self.mode = .deleteBefore(action)
+    }
+    
+    var body: some View {
+        Button {
+            switch mode {
+            case .delete:
+                _ = try! playerRepository.deleteAllPlayer()
+                
+            case let .deleteAfter(action):
+                action()
+                Task {
+                    try await Task.sleep(nanoseconds: 100_000_000)
+                    try playerRepository.deleteAllPlayer()
+                }
+                
+            case let .deleteBefore(action):
+                _ = try! playerRepository.deleteAllPlayer()
+                action()
+            }
+        } label: {
+            Label(titleKey, systemImage: "trash")
+        }
+    }
+}
+
+// For tracking the player count in the preview
+import GRDB
+import GRDBQuery
+
+struct DatabaseButtons_Previews: PreviewProvider {
+    struct PlayerCountRequest: Queryable {
+        static var defaultValue: Int { 0 }
+        
+        func publisher(in playerRepository: PlayerRepository) -> DatabasePublishers.Value<Int> {
+            ValueObservation
+                .tracking(Player.fetchCount)
+                .publisher(in: playerRepository.reader, scheduling: .immediate)
+        }
+    }
+    
+    struct Preview: View {
+        @Query(PlayerCountRequest())
+        var playerCount: Int
+        
+        var body: some View {
+            VStack {
+                Text("Number of players: \(playerCount)")
+                CreatePlayerButton("Create Player")
+                DeletePlayersButton("Delete Players")
+            }
+            .informationBox()
+            .padding()
+        }
+    }
+    
+    static var previews: some View {
+        Preview()
+    }
+}

--- a/Documentation/ObservableDemo/ObservableDemo/Views/InformationStyle.swift
+++ b/Documentation/ObservableDemo/ObservableDemo/Views/InformationStyle.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+/// The style for information text
+struct InformationStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .foregroundColor(.purple)
+            .font(.callout)
+    }
+}
+
+/// The style for information boxes
+struct InformationBox: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .center)
+            .background(Color.purple.opacity(0.07))
+            .buttonStyle(.borderedProminent)
+            .tint(.purple)
+            .cornerRadius(10)
+    }
+}
+
+extension View {
+    func informationStyle() -> some View {
+        modifier(InformationStyle())
+    }
+    
+    func informationBox() -> some View {
+        modifier(InformationBox())
+    }
+}
+
+struct Information_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack {
+            Text("Info 1")
+                .informationStyle()
+            Text("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque et.")
+                .informationStyle()
+            Button("OK") { }
+        }
+        .informationBox()
+        .padding()
+    }
+}

--- a/Documentation/ObservableDemo/ObservableDemo/Views/PlayerEditionView/PlayerEditionView.swift
+++ b/Documentation/ObservableDemo/ObservableDemo/Views/PlayerEditionView/PlayerEditionView.swift
@@ -1,0 +1,60 @@
+import GRDBQuery
+import SwiftUI
+
+/// The sheet for player edition.
+///
+/// In this demo app, this view don't want to remain on screen
+/// whenever the edited player no longer exists in the database.
+struct PlayerEditionView: View {
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentState private var viewModel: PlayerEditionViewModel
+    
+    init(id: Int64) {
+        _viewModel = EnvironmentState {
+            PlayerEditionViewModel(playerRepository: $0.playerRepository, id: id)
+        }
+    }
+    
+    var body: some View {
+        NavigationView {
+            if let player = viewModel.player {
+                VStack {
+                    PlayerFormView(player: player)
+                    Spacer()
+                    VStack(spacing: 10) {
+                        Text("What if another application component deletes the player at the most unexpected moment?")
+                            .informationStyle()
+                        DeletePlayersButton("Delete Player")
+                    }
+                    .informationBox()
+                }
+                .padding(.horizontal)
+                .navigationTitle(player.name)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button("Done") { dismiss() }
+                    }
+                }
+            } else {
+                PlayerNotFoundView()
+            }
+        }
+        .alert(
+            "Ooops, player is gone.",
+            isPresented: $viewModel.gonePlayerAlertPresented) {
+                Button("Dismiss") { dismiss() }
+            }
+    }
+}
+
+struct PlayerEditionView_Previews: PreviewProvider {
+    static var previews: some View {
+        PlayerEditionView(id: 1)
+            .environment(\.playerRepository, .populated(playerId: 1))
+            .previewDisplayName("Existing player")
+        
+        PlayerEditionView(id: -1)
+            .environment(\.playerRepository, .empty())
+            .previewDisplayName("Missing player")
+    }
+}

--- a/Documentation/ObservableDemo/ObservableDemo/Views/PlayerEditionView/PlayerEditionViewModel.swift
+++ b/Documentation/ObservableDemo/ObservableDemo/Views/PlayerEditionView/PlayerEditionViewModel.swift
@@ -1,0 +1,74 @@
+import Combine
+import Observation
+import GRDB
+import Players
+
+/// The view model for ``PlayerEditionView``.
+@Observable
+final class PlayerEditionViewModel {
+    // We handle three distinct cases regarding the presence of the
+    // edited player:
+    private enum PlayerPresence {
+        /// The player exists in the database
+        case existing(Player)
+        
+        /// Player no longer exists, but we have its latest value.
+        case gone(Player)
+        
+        /// Player does not exist, and we don't have any information about it.
+        case missing
+        
+        var player: Player? {
+            switch self {
+            case let .existing(player), let .gone(player):
+                return player
+            case .missing:
+                return nil
+            }
+        }
+        
+        var playerExists: Bool {
+            switch self {
+            case .existing:
+                return true
+            case .gone, .missing:
+                return false
+            }
+        }
+    }
+    
+    /// The player to display.
+    var player: Player? { playerPresence.player }
+    
+    /// A boolean indicating whether the "Player is gone" alert should
+    /// be presented.
+    var gonePlayerAlertPresented = false
+    
+    private var playerPresence: PlayerPresence = .missing
+    private var observationCancellable: AnyCancellable?
+    
+    init(playerRepository: PlayerRepository, id: Int64) {
+        observationCancellable = ValueObservation
+            .tracking(Player.filter(key: id).fetchOne)
+            .publisher(in: playerRepository.reader, scheduling: .immediate)
+            // Use scan in order to detect the three cases of player presence
+            .scan(PlayerPresence.missing) { (previous, player) in
+                if let player {
+                    return .existing(player)
+                } else if let player = previous.player {
+                    return .gone(player)
+                } else {
+                    return .missing
+                }
+            }
+            .sink(
+                receiveCompletion: { _ in /* ignore error */ },
+                receiveValue: { [weak self] playerPresence in
+                    guard let self = self else { return }
+                    self.playerPresence = playerPresence
+                    if !playerPresence.playerExists {
+                        self.gonePlayerAlertPresented = true
+                    }
+                })
+    }
+}

--- a/Documentation/ObservableDemo/ObservableDemo/Views/PlayerFormView/PlayerFormView.swift
+++ b/Documentation/ObservableDemo/ObservableDemo/Views/PlayerFormView/PlayerFormView.swift
@@ -1,0 +1,39 @@
+import GRDBQuery
+import Players
+import SwiftUI
+
+/// The view that edits a player
+struct PlayerFormView: View {
+    @EnvironmentState private var viewModel: PlayerFormViewModel
+    
+    init(player: Player) {
+        _viewModel = EnvironmentState {
+            PlayerFormViewModel(
+                playerRepository: $0.playerRepository,
+                editedPlayer: player)
+        }
+    }
+    
+    var body: some View {
+        Stepper(
+            "Score: \(viewModel.player.score)",
+            onIncrement: { viewModel.incrementScore() },
+            onDecrement: { viewModel.decrementScore() })
+    }
+}
+
+struct PlayerFormView_Previews: PreviewProvider {
+    static var previews: some View {
+        List {
+            Section("Player exists in the database") {
+                PlayerFormView(player: .makeRandom(id: 1))
+                    .environment(\.playerRepository, .populated(playerId: 1))
+            }
+            
+            Section("Player does not exist in the database") {
+                PlayerFormView(player: .makeRandom())
+                    .environment(\.playerRepository, .empty())
+            }
+        }
+    }
+}

--- a/Documentation/ObservableDemo/ObservableDemo/Views/PlayerFormView/PlayerFormViewModel.swift
+++ b/Documentation/ObservableDemo/ObservableDemo/Views/PlayerFormView/PlayerFormViewModel.swift
@@ -1,0 +1,43 @@
+import Observation
+import GRDB
+import Players
+
+/// The view model for ``PlayerFormView``.
+@Observable
+class PlayerFormViewModel {
+    private let playerRepository: PlayerRepository
+    
+    /// The player to display.
+    private(set) var player: Player
+    
+    init(playerRepository: PlayerRepository, editedPlayer player: Player) {
+        self.playerRepository = playerRepository
+        self.player = player
+    }
+    
+    /// Increments the player score.
+    func incrementScore() {
+        updatePlayer { $0.score += 10 }
+    }
+    
+    /// Decrements the player score.
+    func decrementScore() {
+        updatePlayer { $0.score = max(0, $0.score - 10) }
+    }
+    
+    private func updatePlayer(_ transform: (inout Player) -> Void) {
+        do {
+            var updatedPlayer = player
+            transform(&updatedPlayer)
+            try playerRepository.update(updatedPlayer)
+            
+            // Only update view if update was successful in the database
+            player = updatedPlayer
+        } catch RecordError.recordNotFound {
+            // Oops, player does not exist.
+            // Ignore this error: `PlayerEditionView` will dismiss.
+        } catch {
+            // Ignore other errors.
+        }
+    }
+}

--- a/Documentation/ObservableDemo/ObservableDemo/Views/PlayerNotFoundView.swift
+++ b/Documentation/ObservableDemo/ObservableDemo/Views/PlayerNotFoundView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// The view that is displayed when a player can not be found.
+struct PlayerNotFoundView: View {
+    var body: some View {
+        ZStack {
+            Color(UIColor.systemGroupedBackground).ignoresSafeArea()
+            VStack {
+                Spacer()
+                Text("404").font(Font.system(size: 64)).fontWeight(.heavy)
+                Text("😵").font(Font.system(size: 100))
+                Spacer()
+                Spacer()
+                Spacer()
+            }.padding()
+        }
+    }
+}
+
+struct PlayerNotFoundView_Previews: PreviewProvider {
+    static var previews: some View {
+        PlayerNotFoundView()
+    }
+}

--- a/Documentation/ObservableDemo/ObservableDemo/Views/PlayerView.swift
+++ b/Documentation/ObservableDemo/ObservableDemo/Views/PlayerView.swift
@@ -1,0 +1,54 @@
+import Players
+import SwiftUI
+
+struct PlayerView: View {
+    @Environment(\.redactionReasons) var redactionReasons
+    var player: Player
+    var editAction: (() -> Void)?
+    
+    var body: some View {
+        HStack {
+            avatar()
+            
+            VStack(alignment: .leading) {
+                Text(player.name).bold().font(.title3)
+                Text("Score: \(player.score)")
+            }
+            
+            Spacer()
+            
+            if let editAction {
+                Button("Edit", action: editAction)
+            }
+        }
+    }
+    
+    func avatar() -> some View {
+        Group {
+            if redactionReasons.isEmpty {
+                AsyncImage(
+                    url: URL(string: "https://picsum.photos/seed/\(player.photoID)/200"),
+                    content: { image in
+                        image.resizable()
+                    },
+                    placeholder: {
+                        Color(uiColor: UIColor.tertiarySystemFill)
+                    })
+            } else {
+                Color(uiColor: UIColor.tertiarySystemFill)
+            }
+        }
+        .frame(width: 70, height: 70)
+        .cornerRadius(10)
+    }
+}
+
+struct PlayerView_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack {
+            PlayerView(player: .makeRandom(), editAction: { })
+            PlayerView(player: .placeholder).redacted(reason: .placeholder)
+        }
+        .padding()
+    }
+}

--- a/Documentation/ObservableDemo/ObservableDemoTests/ObservableDemoTests.swift
+++ b/Documentation/ObservableDemo/ObservableDemoTests/ObservableDemoTests.swift
@@ -1,0 +1,36 @@
+//
+//  ObservableDemoTests.swift
+//  ObservableDemoTests
+//
+//  Created by Gwendal Roué on 05/08/2023.
+//
+
+import XCTest
+@testable import ObservableDemo
+
+final class ObservableDemoTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/Documentation/ObservableDemo/ObservableDemoUITests/ObservableDemoUITests.swift
+++ b/Documentation/ObservableDemo/ObservableDemoUITests/ObservableDemoUITests.swift
@@ -1,0 +1,41 @@
+//
+//  ObservableDemoUITests.swift
+//  ObservableDemoUITests
+//
+//  Created by Gwendal Roué on 05/08/2023.
+//
+
+import XCTest
+
+final class ObservableDemoUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/Documentation/ObservableDemo/ObservableDemoUITests/ObservableDemoUITestsLaunchTests.swift
+++ b/Documentation/ObservableDemo/ObservableDemoUITests/ObservableDemoUITestsLaunchTests.swift
@@ -1,0 +1,32 @@
+//
+//  ObservableDemoUITestsLaunchTests.swift
+//  ObservableDemoUITests
+//
+//  Created by Gwendal Roué on 05/08/2023.
+//
+
+import XCTest
+
+final class ObservableDemoUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/Sources/GRDBQuery/Documentation.docc/Extensions/EnvironmentStateObject.md
+++ b/Sources/GRDBQuery/Documentation.docc/Extensions/EnvironmentStateObject.md
@@ -1,7 +1,6 @@
 # ``GRDBQuery/EnvironmentStateObject``
 
-A property wrapper that instantiates an observable object from the
-SwiftUI environment.
+A property wrapper that instantiates an observable object from the SwiftUI environment.
 
 ## Overview
 

--- a/Sources/GRDBQuery/EnvironmentState.swift
+++ b/Sources/GRDBQuery/EnvironmentState.swift
@@ -1,0 +1,69 @@
+#if compiler(>=5.9)
+import SwiftUI
+
+// See Documentation.docc/Extensions/EnvironmentState.md
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+@propertyWrapper
+public struct EnvironmentState<Value>: DynamicProperty
+{
+    /// The environment values.
+    @Environment(\.self) private var environmentValues
+    
+    /// The SwiftUI `State` that deals with the lifetime of the value.
+    @State private var core = Core()
+    
+    /// The closure that creates an instance of the value.
+    private let makeValue: (EnvironmentValues) -> Value
+    
+    /// Creates a new ``EnvironmentState`` with a closure that builds a
+    /// value from environment values.
+    public init(_ makeValue: @escaping (EnvironmentValues) -> Value) {
+        self.makeValue = makeValue
+    }
+    
+    /// The underlying value.
+    public var wrappedValue: Value {
+        core.value ?? makeValue(environmentValues)
+    }
+    
+    /// A projection that creates bindings to the properties of the
+    /// underlying object.
+    public var projectedValue: Wrapper {
+        Wrapper(binding: Binding(
+            get: { core.value ?? makeValue(environmentValues) },
+            set: { core.value = $0 }))
+    }
+    
+    /// Part of the SwiftUI `DynamicProperty` protocol. Do not call this method.
+    public func update() {
+        core.update(makeValue: { makeValue(environmentValues) })
+    }
+    
+    /// A wrapper of the underlying object that can create bindings to its
+    /// properties using dynamic member lookup.
+    @dynamicMemberLookup public struct Wrapper {
+        fileprivate let binding: Binding<Value>
+        
+        /// Returns a binding to the resulting value of a given key path.
+        public subscript<U>(dynamicMember keyPath: WritableKeyPath<Value, U>) -> Binding<U> {
+            Binding(
+                get: { binding.wrappedValue[keyPath: keyPath] },
+                set: { binding.wrappedValue[keyPath: keyPath] = $0 })
+        }
+    }
+    
+    /// An observable value that keeps a strong reference to the value,
+    /// and publishes its changes.
+    @Observable
+    class Core {
+        var value: Value?
+        
+        func update(makeValue: () -> Value) {
+            guard value == nil else { return }
+            let value = makeValue()
+            self.value = value
+        }
+    }
+}
+#endif
+


### PR DESCRIPTION
Closing this pull request.

It looks like it is impossible to make it work as expected. In particular, in the following sample code, changing the score from `ScoreView` always triggers a refresh of `NameView`. This does not happen with the regular `@State`, and I was unable to reproduce this behavior despite much frobnication with the `@Observable` runtime.

```swift
@Observable
class Player {
    var name: String
    var score: Int
    
    init(name: String, score: Int) {
        self.name = name
        self.score = score
    }
}

struct TestView: View {
    @EnvironmentState var model: Model
    init() {
        _model = EnvironmentState { _ in
            // Ignore the environment, this is just a debugging example
            Model(name: "Paul", score: 0)
        }
    }
    
    var body: some View {
        Self._printChanges()
        return VStack {
            NameView(name: $model.name)
            ScoreView(score: $model.score)
        }
    }
}

struct NameView: View {
    @Binding var name: String
    
    var body: some View {
        Self._printChanges()
        return VStack {
            Text(name)
            Button("Change Name") {
                // Triggers a refresh of ScoreView :-(
                name = UUID().uuidString
            }
        }
    }
}

struct ScoreView: View {
    @Binding var score: Int
    
    var body: some View {
        Self._printChanges()
        return VStack {
            Text("\(score)")
            Button("Change Score") {
                // Triggers a refresh of NameView :-(
                score += 1
            }
        }
    }
}

```