### PR TITLE
Make Value an associated type of Queryable

### DIFF
--- a/Sources/GRDBQuery/Queryable.swift
+++ b/Sources/GRDBQuery/Queryable.swift
@@ -2,6 +2,9 @@ import Combine
 
 // See Documentation.docc/Extensions/Queryable.md
 public protocol Queryable: Equatable {
+    /// The type of the published values.
+    associatedtype Value
+    
     /// The type that provides database access.
     ///
     /// Any type can fit, as long as the `Queryable` type can build a Combine
@@ -14,7 +17,7 @@ public protocol Queryable: Equatable {
     
     /// The type of the Combine publisher of database values, returned
     /// from ``publisher(in:)``.
-    associatedtype ValuePublisher: Publisher
+    associatedtype ValuePublisher: Publisher where ValuePublisher.Output == Value
     
     /// The default value, used until the Combine publisher publishes its
     /// initial value.
@@ -27,9 +30,4 @@ public protocol Queryable: Equatable {
     ///
     /// - parameter database: Provides access to the database.
     func publisher(in database: DatabaseContext) -> ValuePublisher
-}
-
-extension Queryable {
-    /// The type of the published values.
-    public typealias Value = ValuePublisher.Output
 }


### PR DESCRIPTION
This PR makes it possible to derive sub-protocols of `Queryable`.

---

For example, given an app that has a `PlayerStore` object with the following api:

```swift
import GRDB

struct PlayerStore {
    var reader: GRDB.DatabaseReader { get }
}
```

The app can define convenience protocols as below:

```swift
/// A `Queryable` type that performs a single fetch. It is suitable for
/// views that must not change once they have appeared on screen.
protocol FetchQueryable: Queryable
where DatabaseContext == PlayerStore,
      ValuePublisher == AnyPublisher<Value, any Error>
{
    /// Returns the fetched value.
    func fetch(_ db: Database) throws -> Value
}

extension FetchQueryable {
    func publisher(in store: PlayerStore) -> ValuePublisher {
        Deferred {
            Result {
                try store.reader.read(fetch)
            }
            .publisher
        }
        .eraseToAnyPublisher()
    }
}

/// A `Queryable` type that observes the database.
protocol ObservationQueryable: Queryable
where DatabaseContext == PlayerStore,
      ValuePublisher == AnyPublisher<Value, any Error>
{
    /// Returns the observed value.
    func fetch(_ db: Database) throws -> Value
}

extension ObservationQueryable {
    func publisher(in store: PlayerStore) -> ValuePublisher {
        ValueObservation
            .tracking(fetch)
            .publisher(in: store.reader, scheduling: .immediate)
            .eraseToAnyPublisher()
    }
}
```

This can dramatically simplify the definition of some `Queryable` types:

```diff
-struct PlayersRequest: Queryable {
+struct PlayersRequest: FetchQueryable {
     static var defaultValue: [Player] = []
     
-    func publisher(in store: PlayerStore) -> AnyPublisher<[Player], any Error> {
-        Deferred {
-            Result {
-                try store.reader.read { db in
-                    try Player.fetchAll(db)
-                }
-            }
-            .publisher
-        }
-        .eraseToAnyPublisher()
-    }
+    func fetch(_ db: Database) throws -> [Player] {
+        try Player.fetchAll(db)
+    }
 }

-struct TeamsRequest: Queryable {
+struct TeamsRequest: ObservationQueryable {
     static var defaultValue: [Team] = []
     
-    func publisher(in store: PlayerStore) -> AnyPublisher<[Team], any Error> {
-        ValueObservation
-            .tracking { db in
-                try Team.fetchAll(db)
-            }
-            .publisher(in: store.reader, scheduling: .immediate)
-            .eraseToAnyPublisher()
-    }
+    func fetch(_ db: Database) throws -> [Team] {
+        try Team.fetchAll(db)
+    }
 }
```
