### PR TITLE
adds QueryableOptions.assertNoFailure to treat errors as fatalError

### DIFF
--- a/Sources/GRDBQuery/Queryable+DatabaseContext/FetchQueryable.swift
+++ b/Sources/GRDBQuery/Queryable+DatabaseContext/FetchQueryable.swift
@@ -55,6 +55,7 @@ extension TopLevelDatabaseReader {
                     .eraseToAnyPublisher()
             }
         }
+        .assertNoFailure(if: queryableOptions.contains(.assertNoFailure))
         .eraseToAnyPublisher()
     }
 }

--- a/Sources/GRDBQuery/Queryable+DatabaseContext/QueryableOptions.swift
+++ b/Sources/GRDBQuery/Queryable+DatabaseContext/QueryableOptions.swift
@@ -7,6 +7,7 @@
 ///
 /// - ``async``
 /// - ``constantRegion``
+/// - ``assertNoFailure``
 public struct QueryableOptions: OptionSet, Sendable {
     public let rawValue: Int
     

--- a/Sources/GRDBQuery/Queryable+DatabaseContext/QueryableOptions.swift
+++ b/Sources/GRDBQuery/Queryable+DatabaseContext/QueryableOptions.swift
@@ -60,8 +60,8 @@ public struct QueryableOptions: OptionSet, Sendable {
     
     /// By default, any error that occurs can be accessed using ``Query/Wrapper/error``
     /// and is otherwise ignored.
-    /// With this option, assertNoFailure() is called on the combine publisher, which causes any error
-    /// to be treated as a fatalError which will terminate the app.
+    /// With this option, errors that happen while accessing the
+    /// database terminate the app with a fatal error.
     public static let assertNoFailure = QueryableOptions(rawValue: 1 << 2)
     
     /// The default options.

--- a/Sources/GRDBQuery/Queryable+DatabaseContext/QueryableOptions.swift
+++ b/Sources/GRDBQuery/Queryable+DatabaseContext/QueryableOptions.swift
@@ -58,6 +58,12 @@ public struct QueryableOptions: OptionSet, Sendable {
     /// ``PresenceObservationQueryable`` types.
     public static let constantRegion = QueryableOptions(rawValue: 1 << 1)
     
+    /// By default, any error that occurs can be accessed using ``Query/Wrapper/error``
+    /// and is otherwise ignored.
+    /// With this option, assertNoFailure() is called on the combine publisher, which causes any error
+    /// to be treated as a fatalError which will terminate the app.
+    public static let assertNoFailure = QueryableOptions(rawValue: 1 << 2)
+    
     /// The default options.
     public static let `default`: QueryableOptions = []
 }

--- a/Sources/GRDBQuery/Queryable+DatabaseContext/ValueObservationQueryable.swift
+++ b/Sources/GRDBQuery/Queryable+DatabaseContext/ValueObservationQueryable.swift
@@ -68,7 +68,21 @@ extension TopLevelDatabaseReader {
                     .eraseToAnyPublisher()
             }
         }
+        .assertNoFailure(if: queryableOptions.contains(.assertNoFailure))
         .eraseToAnyPublisher()
+    }
+}
+
+
+extension Publisher {
+    func assertNoFailure(if condition: Bool) -> AnyPublisher<Output, Failure> {
+        if !condition {
+            self.eraseToAnyPublisher()
+        } else {
+            self.assertNoFailure()
+                .setFailureType(to: Failure.self)
+                .eraseToAnyPublisher()
+        }
     }
 }
 


### PR DESCRIPTION
Allows to set queryableOptions to QueryableOptions.assertNoFailure to treat errors as fatal.

See https://github.com/groue/GRDBQuery/discussions/63#discussion-7914213