### PR TITLE
Enhancement: Add ability to print Combine.Publisher flow. 

### DIFF
--- a/Documentation/DemoApps.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Documentation/DemoApps.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "8b3eda36da18d89a659acf1bf9271f6614d3a169035b13ebe8ce220e231fe8a6",
+  "originHash" : "cb18ed509d253f716a675c3aa0d72e4cba16c89893ddd5e9b601ccf2127bf5ff",
   "pins" : [
     {
       "identity" : "grdb.swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/GRDB.swift.git",
       "state" : {
-        "revision" : "47a7ddf08a619fff3e215df321fba9f4d77413e5",
-        "version" : "7.0.0-beta"
+        "revision" : "04e73c26c4ce8218ab85aaf791942bb0b204f330",
+        "version" : "7.4.1"
       }
     }
   ],

--- a/Documentation/MVVMDemo/MVVMDemo.xcodeproj/project.pbxproj
+++ b/Documentation/MVVMDemo/MVVMDemo.xcodeproj/project.pbxproj
@@ -461,6 +461,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"MVVMDemo/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -489,6 +490,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"MVVMDemo/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/Documentation/QueryDemo/QueryDemo/Views/AppView.swift
+++ b/Documentation/QueryDemo/QueryDemo/Views/AppView.swift
@@ -10,7 +10,7 @@ struct AppView: View {
         var id: Int64
     }
     
-    @Query(AnyPlayerRequest())
+    @Query(AnyPlayerRequest(), printPublisherConfiguration: .init(prefix: "\(#function)"))
     private var player: Player?
     
     @State private var editedPlayer: EditedPlayer?

--- a/Sources/GRDBQuery/Query+DatabaseContext.swift
+++ b/Sources/GRDBQuery/Query+DatabaseContext.swift
@@ -21,9 +21,12 @@ extension Query where Request.Context == DatabaseContext {
     ///
     /// - parameter request: An initial ``Queryable`` request.
     public init(
-        _ request: Request
+        _ request: Request,
+        printPublisherConfiguration: QueryPublisherPrintConfiguration? = nil
     ) {
-        self.init(request, in: \.databaseContext)
+        self.init(request,
+                  in: \.databaseContext,
+                  printPublisherConfiguration: printPublisherConfiguration)
     }
     
     /// Creates a `Query` that feeds from the `databaseContext`
@@ -50,9 +53,12 @@ extension Query where Request.Context == DatabaseContext {
     ///
     /// - parameter request: A ``Queryable`` request.
     public init(
-        constant request: Request
+        constant request: Request,
+        printPublisherConfiguration: QueryPublisherPrintConfiguration? = nil
     ) {
-        self.init(constant: request, in: \.databaseContext)
+        self.init(constant: request,
+                  in: \.databaseContext,
+                  printPublisherConfiguration: printPublisherConfiguration)
     }
     
     /// Creates a `Query` that feeds from the `databaseContext`
@@ -88,8 +94,11 @@ extension Query where Request.Context == DatabaseContext {
     ///
     /// - parameter request: A SwiftUI binding to a ``Queryable`` request.
     public init(
-        _ request: Binding<Request>
+        _ request: Binding<Request>,
+        printPublisherConfiguration: QueryPublisherPrintConfiguration? = nil
     ) {
-        self.init(request, in: \.databaseContext)
+        self.init(request,
+                  in: \.databaseContext,
+                  printPublisherConfiguration: printPublisherConfiguration)
     }
 }

--- a/Sources/GRDBQuery/Query+VoidContext.swift
+++ b/Sources/GRDBQuery/Query+VoidContext.swift
@@ -29,8 +29,11 @@ extension Query where Request.Context == Void {
     /// ```
     ///
     /// - parameter request: An initial ``Queryable`` request.
-    public init(_ request: Request) {
-        self.init(request, in: \.void)
+    public init(_ request: Request,
+                printPublisherConfiguration: QueryPublisherPrintConfiguration? = nil) {
+        self.init(request,
+                  in: \.void,
+                  printPublisherConfiguration: printPublisherConfiguration)
     }
     
     /// Creates a `Query`, given a SwiftUI binding to a ``Queryable``
@@ -73,8 +76,11 @@ extension Query where Request.Context == Void {
     /// ```
     ///
     /// - parameter request: A SwiftUI binding to a ``Queryable`` request.
-    public init(_ request: Binding<Request>) {
-        self.init(request, in: \.void)
+    public init(_ request: Binding<Request>,
+                printPublisherConfiguration: QueryPublisherPrintConfiguration? = nil) {
+        self.init(request,
+                  in: \.void,
+                  printPublisherConfiguration: printPublisherConfiguration)
     }
     
     /// Creates a `Query`, given a ``Queryable`` request that uses
@@ -109,8 +115,11 @@ extension Query where Request.Context == Void {
     /// ```
     ///
     /// - parameter request: A ``Queryable`` request.
-    public init(constant request: Request) {
-        self.init(constant:request, in: \.void)
+    public init(constant request: Request,
+                printPublisherConfiguration: QueryPublisherPrintConfiguration? = nil) {
+        self.init(constant:request,
+                  in: \.void,
+                  printPublisherConfiguration: printPublisherConfiguration)
     }
 }
 


### PR DESCRIPTION
Database allows to track all sql statements via `track` method. 
What about adding possibility to track any publisher event by providing to Query some configuration(`QueryPublisherPrintConfiguration` in PR), which defines parameters for Combine.Publisher.print method?

<img width="946" alt="Screenshot 2025-04-24 at 11 36 12" src="https://github.com/user-attachments/assets/91f27bbd-eb7a-4cbb-b7b7-22abdeb3e9dd" />
